### PR TITLE
Fix font awesome color issue

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -583,6 +583,18 @@ img {
   overflow: hidden;
 }
 
+.palette-one .fa, .palette-one .far {
+  color: var(--color-primary, #0B1A26);
+}
+
+.palette-two .fa, .palette-two .far {
+  color: var(--color-primary-2, #FFFFFF);
+}
+
+.palette-three .fa, .palette-three .far {
+  color: var(--color-primary-3, #0B1A26);
+}
+
 .tagline {
   display: inline-block;
   vertical-align: top;

--- a/assets/top-bar.css
+++ b/assets/top-bar.css
@@ -69,29 +69,14 @@
   background: var(--background-primary, #FFFFFF);
 }
 
-.palette-one.top-bar__wrapper .fa,
-.palette-one.top-bar__wrapper .far {
-  color: var(--color-primary, #0B1A26);
-}
-
 .palette-two.top-bar__wrapper {
   color: var(--color-primary-2, #FFFFFF);
   background: var(--background-primary-2, #0B1A26);
 }
 
-.palette-two.top-bar__wrapper .fa,
-.palette-two.top-bar__wrapper .far {
-  color: var(--color-primary-2, #FFFFFF);
-}
-
 .palette-three.top-bar__wrapper {
   color: var(--color-primary-3, #0B1A26);
   background: var(--background-primary-3, #F4B841);
-}
-
-.palette-three.top-bar__wrapper .fa,
-.palette-three.top-bar__wrapper .far {
-  color: var(--color-primary-3, #0B1A26);
 }
 
 @media (min-width: 992px) {

--- a/snippets/icon.liquid
+++ b/snippets/icon.liquid
@@ -15,18 +15,6 @@
 
 {% endcomment %}
 
-{% style %}
-  .palette-one .fa, .palette-one .far {
-    color: var(--color-primary, #0B1A26);
-  }
-  .palette-two .fa, .palette-two .far {
-    color: var(--color-primary-2, #FFFFFF);
-  }
-  .palette-three .fa, .palette-three .far {
-    color: var(--color-primary-3, #0B1A26);
-  }
-{% endstyle %}
-
 {% unless icon == "empty" %}
   <span class="icon">
     <i class="{% if style == "outline" %}far{% else %}fa{% endif %} fa-{{- icon -}}" aria-hidden="true"></i>


### PR DESCRIPTION
Currently, the colors of `font-awesome` are loading with `icon.liquid` snippet file, and the colors of star icons in the Testimonials section are rendered with `font-awesome` as well but don't use the `icon` snippet, so styles are lost if they are not loaded with other sections on the page.

So the purpose of this PR is to move styles of the color of `font-awesome` icons to the `base.css` file

**Before**:
![Arc_2024-05-20 13-09-35@2x](https://github.com/booqable/chameleon-theme/assets/40244261/f2a548cf-737f-4074-a7dc-25945108b24b)

**After**:
![Arc_2024-05-20 13-07-27@2x](https://github.com/booqable/chameleon-theme/assets/40244261/638ce1cf-6915-4adc-bf24-948a7fa52b4d)
