### PR TITLE
Avoid broken layout with long words

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -116,7 +116,7 @@ body {
   min-height: 100%;
   width: 100%;
   overflow-x: hidden;
-  word-break: break-word;
+  overflow-wrap: break-word;
 }
 
 body::-webkit-scrollbar {

--- a/assets/base.css
+++ b/assets/base.css
@@ -116,6 +116,7 @@ body {
   min-height: 100%;
   width: 100%;
   overflow-x: hidden;
+  word-break: break-word;
 }
 
 body::-webkit-scrollbar {

--- a/assets/footer.css
+++ b/assets/footer.css
@@ -28,7 +28,6 @@
   line-height: var(--line-height-md, 1.3333);
   font-weight: var(--font-weight-semibold, 600);
   margin: 0;
-  word-break: break-word;
 }
 
 .footer__menu-heading {

--- a/assets/header.css
+++ b/assets/header.css
@@ -57,7 +57,6 @@
   font-weight: var(--font-weight-semibold, 600);
   margin: 0;
   color: currentColor;
-  word-break: break-word;
 }
 
 .header__logo-image {


### PR DESCRIPTION
Currently, we can get a broken layout with too long words, especially it's clearly visible on narrow blocks such as in the Columns section. So in this case we have a `contentEditor` field and the customer added the email and wrapped it in the heading tag but it goes out of the block

So this PR's purpose is to add the CSS `break-word` property and avoid such issues throughout the layout

Before:
<img width="356" alt="Screenshot 2024-06-20 at 14 31 39" src="https://github.com/booqable/chameleon-theme/assets/40244261/cae5f9ec-6d14-481b-8e32-86271c55d4ae">

![Slack_2024-06-24 12-32-05@2x](https://github.com/booqable/chameleon-theme/assets/40244261/3ac64da0-9d02-4e08-8fea-221449937d14)


After:
![Slack_2024-06-24 12-31-41@2x](https://github.com/booqable/chameleon-theme/assets/40244261/f4e73906-9111-457f-8734-95602242d02c)
