### PR TITLE
Remove stripping html and truncating of product excerpts

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -116,7 +116,7 @@ body {
   min-height: 100%;
   width: 100%;
   overflow-x: hidden;
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
 }
 
 body::-webkit-scrollbar {

--- a/assets/images.css
+++ b/assets/images.css
@@ -108,9 +108,21 @@
   transform: translate(-50%, -50%);
 }
 
+.images__vision--video {
+  container: images-vision / size;
+}
+
 .images__video {
   pointer-events: none;
-  height: 100%;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 100%;
+  height: auto;
+  aspect-ratio: 16 / 9;
+  max-width: none;
+  object-fit: cover;
 }
 
 .images .carousel__wrapper {
@@ -222,18 +234,6 @@
     display: none;
   }
 
-  .images__video {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    width: 100%;
-    height: auto;
-    aspect-ratio: 16 / 9;
-    max-width: none;
-    object-fit: cover;
-  }
-
   .images__text-area {
     justify-content: var(--text-justify-content, flex-start);
     align-items: var(--text-align-items, center);
@@ -257,11 +257,6 @@
 
   .images__wrapper .date-picker__title {
     justify-content: var(--text-justify-content, flex-start);
-  }
-
-  .images__wrapper-full-height .images__video {
-    width: auto;
-    height: 100%;
   }
 
   .images__wrapper.section-with-date-picker .images__container {
@@ -293,9 +288,16 @@
   }
 }
 
-@media (min-width: 1920px) {
-  .images__wrapper-full-height .images__video {
+@container (aspect-ratio > 16 / 9) {
+  .images__vision--video .images__video {
     width: 100%;
     height: auto;
+  }
+}
+
+@container (aspect-ratio <= 16 / 9) {
+  .images__vision--video .images__video {
+    width: auto;
+    height: 100%;
   }
 }

--- a/assets/main.js
+++ b/assets/main.js
@@ -5,12 +5,14 @@ class Main {
     this.selector = {
       datePicker: "bq-date-picker",
       datePickerBlock: ".date-picker-instance",
-      image: ".focal-image"
+      image: ".focal-image",
+      excerpt: ".product-card__description"
     }
 
     this.modifier = {
       loaded: "loaded",
-      resize: "resize-active"
+      resize: "resize-active",
+      truncated: "truncated"
     }
 
     this.data = {
@@ -20,7 +22,13 @@ class Main {
 
     this.cssVar = {
       datePickerHeight: '--date-picker-height',
-      datePickerBlockHeight: '--date-picker-block-height',
+      datePickerBlockHeight: '--date-picker-block-height'
+    }
+
+    this.cssProp = {
+      maxHeight: 'max-height',
+      paddingTop: 'padding-top',
+      paddingBottom: 'padding-bottom'
     }
 
     this.time = 500;
@@ -38,15 +46,18 @@ class Main {
   elements() {
     this.datePicker = document.querySelector(this.selector.datePicker);
     this.datePickerBlock = document.querySelector(this.selector.datePickerBlock);
+    this.excerpts = document.querySelectorAll(this.selector.excerpt);
   }
 
   events() {
     this.setLoadedClass();
     this.focalImages();
+    this.setTruncationClass();
     setTimeout(() => this.getDatePickerHeight(), 1000);
 
     window.addEventListener("resize", this.getDatePickerHeight.bind(this));
     window.addEventListener("resize", this.setResizeClass.bind(this));
+    window.addEventListener("resize", this.setTruncationClass.bind(this));
   }
 
   getDatePickerHeight() {
@@ -79,6 +90,25 @@ class Main {
   // adding class after loading content
   setLoadedClass() {
     this.block.classList.add(this.modifier.loaded);
+  }
+
+  // set class for truncation product card description
+  setTruncationClass() {
+    if (!this.excerpts.length) return false;
+
+    const styles = window.getComputedStyle(this.excerpts[0]),
+          paddingTop = parseInt(styles.getPropertyValue(this.cssProp.paddingTop)),
+          paddingBottom = parseInt(styles.getPropertyValue(this.cssProp.paddingBottom)),
+          maxHeight = parseInt(styles.getPropertyValue(this.cssProp.maxHeight)),
+          minHeight = maxHeight / 2 + paddingBottom + paddingTop;
+
+    this.excerpts.forEach(excerpt => {
+      const height = excerpt.getBoundingClientRect().height
+
+      height > minHeight
+        ? excerpt.classList.add(this.modifier.truncated)
+        : excerpt.classList.remove(this.modifier.truncated)
+    })
   }
 
   // change focus positioning of image

--- a/assets/product-card.css
+++ b/assets/product-card.css
@@ -42,9 +42,9 @@
 
 .product-card__meta {
   padding: 17px 15px;
+  font-size: 14px;
   display: flex;
   flex-direction: column;
-  flex-grow: 1;
 }
 
 .product-card__title {
@@ -56,13 +56,40 @@
 }
 
 .product-card__description {
-  font-size: 14px;
   padding: 4px 0 8px;
   flex-grow: 0;
+  overflow: hidden;
+  max-height: 130px;
 }
 
 .product-card__description:last-child {
   padding-bottom: 0;
+}
+
+.product-card__description.truncated {
+  position: relative;
+  flex-grow: 1;
+}
+
+.product-card__description.truncated + .product-card__price-info {
+  flex-grow: 0;
+}
+
+.product-card__description.truncated:after {
+  content: "";
+  display: block;
+  width: 100%;
+  height: 60px;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+}
+
+.product-card__meta .product-card__description dt,
+.product-card__meta .product-card__description dd,
+.product-card__meta .product-card__description li,
+.product-card__meta .product-card__description li li {
+  font-size: inherit;
 }
 
 .product-card__price-info {
@@ -120,6 +147,10 @@ bq-product-availability[visible="true"] {
   background: var(--color-image-placeholder, #0B1A2626);
 }
 
+.palette-one .product-card__description.truncated:after {
+  background: linear-gradient(to top, var(--background-primary, #FFFFFF) 0%, var(--background-primary, #FFFFFF) 30%, var(--background-primary-00, #FFFFFF00) 100%);
+}
+
 .palette-one .product-card__price-info {
   color: var(--color-primary, #0B1A26);
 }
@@ -143,6 +174,10 @@ bq-product-availability[visible="true"] {
   background: var(--color-image-placeholder-2, #FFFFFF47);
 }
 
+.palette-two .product-card__description.truncated:after {
+  background: linear-gradient(to top, var(--background-primary-2, #0B1A26) 0%, var(--background-primary-2, #0B1A26) 30%, var(--background-primary-2-00, #0B1A2600) 100%);
+}
+
 .palette-two .product-card__price-info {
   color: var(--color-primary-2, #FFFFFF);
 }
@@ -164,6 +199,10 @@ bq-product-availability[visible="true"] {
 
 .palette-three .product-card__vision.no-image {
   background: var(--color-image-placeholder-3, #0B1A2626);
+}
+
+.palette-three .product-card__description.truncated:after {
+  background: linear-gradient(to top, var(--background-primary-3, #F4B841) 0%, var(--background-primary-3, #F4B841) 30%, var(--background-primary-3-00, #F4B84100) 100%);
 }
 
 .palette-three .product-card__price-info {

--- a/sections/hero-search.liquid
+++ b/sections/hero-search.liquid
@@ -1,17 +1,17 @@
 {{ "hero.css" | asset_url | stylesheet_tag }}
 
-{%- assign title                 = section.settings.title -%}
-{%- assign message               = section.settings.message -%}
-{%- assign results_label         = section.settings.results_label -%}
-{%- assign button_label          = section.settings.button_label -%}
-{%- assign image                 = section.settings.image -%}
-{%- assign color_palette         = section.settings.color_palette -%}
-{%- assign overlay_opacity       = section.settings.overlay_opacity -%}
-{%- assign padding_top           = section.settings.padding_top -%}
-{%- assign padding_bottom        = section.settings.padding_bottom -%}
-{%- assign padding_top_mobile    = section.settings.padding_top_mobile -%}
-{%- assign padding_bottom_mobile = section.settings.padding_bottom_mobile -%}
 {%- assign background_style      = settings.background_style -%}
+{%- assign button_label          = section.settings.button_label -%}
+{%- assign color_palette         = section.settings.color_palette -%}
+{%- assign image                 = section.settings.image -%}
+{%- assign message               = section.settings.message -%}
+{%- assign overlay_opacity       = section.settings.overlay_opacity -%}
+{%- assign padding_bottom        = section.settings.padding_bottom -%}
+{%- assign padding_bottom_mobile = section.settings.padding_bottom_mobile -%}
+{%- assign padding_top           = section.settings.padding_top -%}
+{%- assign padding_top_mobile    = section.settings.padding_top_mobile -%}
+{%- assign results_label         = section.settings.results_label -%}
+{%- assign title                 = section.settings.title -%}
 
 {%- if results_count > 0 -%}
   {%- assign show_datepicker = true -%}

--- a/sections/hero.liquid
+++ b/sections/hero.liquid
@@ -1,16 +1,17 @@
 {{ "hero.css" | asset_url | stylesheet_tag }}
 
-{%- assign custom_title          = section.settings.custom_title -%}
-{%- assign custom_description    = section.settings.custom_description -%}
-{%- assign show_datepicker       = section.settings.show_datepicker -%}
-{%- assign image                 = section.settings.image -%}
-{%- assign color_palette         = section.settings.color_palette -%}
-{%- assign overlay_opacity       = section.settings.overlay_opacity -%}
-{%- assign padding_top           = section.settings.padding_top -%}
-{%- assign padding_bottom        = section.settings.padding_bottom -%}
-{%- assign padding_top_mobile    = section.settings.padding_top_mobile -%}
-{%- assign padding_bottom_mobile = section.settings.padding_bottom_mobile -%}
 {%- assign background_style      = settings.background_style -%}
+{%- assign color_palette         = section.settings.color_palette -%}
+{%- assign custom_description    = section.settings.custom_description -%}
+{%- assign custom_title          = section.settings.custom_title -%}
+{%- assign image                 = section.settings.image -%}
+{%- assign overlay_opacity       = section.settings.overlay_opacity -%}
+{%- assign padding_bottom        = section.settings.padding_bottom -%}
+{%- assign padding_bottom_mobile = section.settings.padding_bottom_mobile -%}
+{%- assign padding_top           = section.settings.padding_top -%}
+{%- assign padding_top_mobile    = section.settings.padding_top_mobile -%}
+{%- assign page_title            = page_title | split: " | " | first | remove: ":"-%}
+{%- assign show_datepicker       = section.settings.show_datepicker -%}
 
 {%- if show_datepicker -%}
   {%- render 'background-accent', color_palette: color_palette, settings: settings -%}

--- a/sections/images.liquid
+++ b/sections/images.liquid
@@ -48,7 +48,7 @@
       {%- when 'large' -%}
         --height: 940px;
       {%- when 'full' -%}
-        --height: 100vh;
+        --height: calc(100vh - var(--header-height, 99px));
     {%- endcase -%}
 
     {%- case padding_top -%}
@@ -116,7 +116,7 @@
     {%- endcapture -%}
   {%- endif -%}
 
-  <div class="images__wrapper{% if height == "full" or height == "large" %} images__wrapper-full-height{% endif %}{% if full_width %} images__wrapper-full-width{% endif %}{% if show_datepicker and datepicker_position == "bottom" %} section-with-date-picker{% endif %}{% if color_palette != blank %} palette-{{ color_palette }}{%- endif -%}" style="{{- variables | escape -}}">
+  <div class="images__wrapper{% if full_width %} images__wrapper-full-width{% endif %}{% if show_datepicker and datepicker_position == "bottom" %} section-with-date-picker{% endif %}{% if color_palette != blank %} palette-{{ color_palette }}{%- endif -%}" style="{{- variables | escape -}}">
     {%- if carousel -%}
       <div class="carousel carousel__edges carousel__{{- effect -}}-effect{% if pause %} carousel__pause{% endif %}{% if show_datepicker and datepicker_position == "bottom" %} carousel-with-date-picker{%- endif -%}" aria-role="Gallery" data-dafault-color="{{- default_color -}}">
         <input class="carousel__timer" type="hidden" name="hidden" value="{{- timer -}}" aria-hidden="true">
@@ -364,7 +364,7 @@
                     </div>
                   </div>
 
-                  <div class="images__vision" {% if show_overlay %}style="{{- image_variables | escape -}}"{%- endif -%}>
+                  <div class="images__vision{% if video_url != blank %} images__vision--video{%- endif -%}" {% if show_overlay %}style="{{- image_variables | escape -}}"{%- endif -%}>
                     {%- if video_url contains "youtube.com" -%}
                       {%- assign video_drop = video_url | split: "?v=" -%}
                       {%- assign video_id   = video_drop | last | strip -%}
@@ -506,7 +506,7 @@
             "type": "text",
             "id": "video_url",
             "label": "Video URL (optional)",
-            "info": "Youtube, Vimeo. If you paste video link here, any images will be ignored"
+            "info": "Youtube, Vimeo. If you paste video link here, any images will be ignored. Preferred format 16:9"
           },
           {
             "type": "text",

--- a/sections/mosaic.liquid
+++ b/sections/mosaic.liquid
@@ -109,7 +109,7 @@
                 {%- endif -%}
 
                 {%- if text != blank -%}
-                  <div class="mosaic__text bq-content rx-content">{{- text | strip_html | truncate: 200, " ..."  -}}</div>
+                  <div class="mosaic__text bq-content rx-content">{{- text -}}</div>
                 {%- endif -%}
 
                 {%- if article_btn != blank and article_btn_url != blank -%}

--- a/sections/products.liquid
+++ b/sections/products.liquid
@@ -1,45 +1,55 @@
+{%- assign blocks     = section.blocks -%}
 {%- assign collection = section.settings.collection -%}
-{%- assign blocks = section.blocks -%}
 
-{%- if blocks.size > 0 or collection.items_count > 0 -%}
+{%- if collection != blank -%}
+  {%- assign items         = collection.items -%}
+  {%- assign items_type    = "collection" -%}
+  {%- assign size          = collection.items_count -%}
+{%- else -%}
+  {%- assign items         = blocks -%}
+  {%- assign items_type    = "blocks" -%}
+  {%- assign product_items = "" -%}
 
+  {%- for item in items -%}
+    {%- if product_items == "" -%}
+      {%- assign product_items = item.id -%}
+    {%- else -%}
+      {%- assign product_items = product_items | append: ", " | append: item.id -%}
+    {%- endif -%}
+  {%- endfor -%}
+
+  {%- assign product_items_arr = product_items | split: ", " -%}
+  {%- assign size = product_items_arr | size -%}
+{%- endif -%}
+
+{%- if size > 0 -%}
   {{ "products.css" | asset_url | stylesheet_tag }}
   {{ "product-card.css" | asset_url | stylesheet_tag }}
 
-  {%- assign show_carousel         = section.settings.show_carousel -%}
-  {%- assign show_navigation       = section.settings.show_navigation -%}
-  {%- assign show_pagination       = section.settings.show_pagination -%}
+  {%- assign carousel              = false -%}
   {%- assign color_palette         = section.settings.color_palette -%}
-  {%- assign padding_top           = section.settings.padding_top -%}
-  {%- assign padding_bottom        = section.settings.padding_bottom -%}
-  {%- assign padding_top_mobile    = section.settings.padding_top_mobile -%}
-  {%- assign padding_bottom_mobile = section.settings.padding_bottom_mobile -%}
-  {%- assign timer                 = section.settings.timer -%}
-  {%- assign show_excerpt          = section.settings.show_excerpt -%}
   {%- assign image_placeholder     = settings.image_placeholder -%}
   {%- assign is_focal              = settings.use_focal_images -%}
   {%- assign items_limit           = 12 -%}
-  {%- assign carousel              = false -%}
+  {%- assign padding_bottom        = section.settings.padding_bottom -%}
+  {%- assign padding_bottom_mobile = section.settings.padding_bottom_mobile -%}
+  {%- assign padding_top           = section.settings.padding_top -%}
+  {%- assign padding_top_mobile    = section.settings.padding_top_mobile -%}
+  {%- assign show_carousel         = section.settings.show_carousel -%}
+  {%- assign show_excerpt          = section.settings.show_excerpt -%}
+  {%- assign show_navigation       = section.settings.show_navigation -%}
+  {%- assign show_pagination       = section.settings.show_pagination -%}
+  {%- assign timer                 = section.settings.timer -%}
 
-  {%- if collection != blank -%}
-    {%- assign items = collection.items -%}
-    {%- assign items_type = "collection" -%}
-
-    {%- if collection.items_count > 1 and show_carousel -%}
-      {%- assign carousel = true -%}
-    {%- endif -%}
-  {%- else -%}
-    {%- assign items = blocks -%}
-    {%- assign items_type = "blocks" -%}
-
-    {%- if blocks.size > 1 and show_carousel -%}
-      {%- assign carousel = true -%}
-    {%- endif -%}
-  {%- endif -%}
-
-  {%- if carousel -%}
+  {%- if size > 1 and show_carousel -%}
     {{ "carousel.css" | asset_url | stylesheet_tag }}
+
+    {%- assign carousel = true -%}
   {%- endif -%}
+
+  {% unless show_pagination %}
+    {%- assign items_limit = nil -%}
+  {% endunless %}
 
   {% comment %} CSS variables start {% endcomment %}
   {%- capture variables -%}

--- a/snippets/product-card.liquid
+++ b/snippets/product-card.liquid
@@ -49,7 +49,7 @@
   {%- assign id      = product.id -%}
   {%- assign url     = product.url -%}
   {%- assign name    = product.name -%}
-  {%- assign excerpt = product.description | strip_html | truncate: 118, " ..." -%}
+  {%- assign excerpt = product.description -%}
   {%- assign price   = product | product_price -%}
   {%- assign period  = product | product_price_label -%}
 
@@ -101,7 +101,7 @@
     </h3>
 
     {%- if excerpt != blank and show_excerpt -%}
-      <div class="product-card__description">{{- excerpt -}}</div>
+      <div class="product-card__description bq-content rx-content">{{- excerpt -}}</div>
     {%- endif -%}
 
     {%- if price != blank and period != blank -%}

--- a/snippets/root-styles.liquid
+++ b/snippets/root-styles.liquid
@@ -245,6 +245,11 @@
     {%- endif -%}
   }
 
+  #cc-main {
+    --cc-btn-border-radius: var(--border-radius-dynamic);
+    --cc-modal-border-radius: var(--border-radius-rounded);
+  }
+
   {%- case settings.cookie_notice_color_palette -%}
     {%- when 'one' -%}
       #cc-main {
@@ -259,6 +264,7 @@
         --cc-btn-primary-border-color: transparent;
 
         --cc-btn-primary-hover-bg: var(--background-accent-hover);
+        --cc-btn-primary-hover-color: var(--color-accent);
         --cc-btn-primary-hover-border-color: var(--background-accent-hover);
 
         --cc-btn-secondary-bg: transparent;
@@ -293,6 +299,7 @@
         --cc-btn-primary-border-color: transparent;
 
         --cc-btn-primary-hover-bg: var(--background-accent-2-hover);
+        --cc-btn-primary-hover-color: var(--color-accent-2);
         --cc-btn-primary-hover-border-color: var(--background-accent-2-hover);
 
         --cc-btn-secondary-bg: transparent;
@@ -327,6 +334,7 @@
         --cc-btn-primary-border-color: transparent;
 
         --cc-btn-primary-hover-bg: var(--background-accent-3-hover);
+        --cc-btn-primary-hover-color: var(--color-accent-3);
         --cc-btn-primary-hover-border-color: var(--background-accent-3-hover);
 
         --cc-btn-secondary-bg: transparent;


### PR DESCRIPTION
This PR's goal is to remove `strip_html` and `truncatewords` filters to save all the styling of reach text.

Also, instead of 3 dots at the end, it should add a linear gradient to the bottom of the product description on product cards dynamically, because else if the description is too small it's overlapped with the gradient and is non-visible at all.

Before:
![Arc_2024-07-26 14-13-25@2x](https://github.com/user-attachments/assets/625ca687-d6f5-42bb-a788-03b8b5b9ffa3)


After:
![Arc_2024-07-26 14-39-13@2x](https://github.com/user-attachments/assets/28f1c01a-8b6e-4daa-ac76-d0556b3ec398)