### PR TITLE
Remove stripping HTML and truncating of product excerpts

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -5,14 +5,12 @@ class Main {
     this.selector = {
       datePicker: "bq-date-picker",
       datePickerBlock: ".date-picker-instance",
-      image: ".focal-image",
-      excerpt: ".product-card__description"
+      image: ".focal-image"
     }
 
     this.modifier = {
       loaded: "loaded",
-      resize: "resize-active",
-      truncated: "truncated"
+      resize: "resize-active"
     }
 
     this.data = {
@@ -23,12 +21,6 @@ class Main {
     this.cssVar = {
       datePickerHeight: '--date-picker-height',
       datePickerBlockHeight: '--date-picker-block-height'
-    }
-
-    this.cssProp = {
-      maxHeight: 'max-height',
-      paddingTop: 'padding-top',
-      paddingBottom: 'padding-bottom'
     }
 
     this.time = 500;
@@ -46,18 +38,15 @@ class Main {
   elements() {
     this.datePicker = document.querySelector(this.selector.datePicker);
     this.datePickerBlock = document.querySelector(this.selector.datePickerBlock);
-    this.excerpts = document.querySelectorAll(this.selector.excerpt);
   }
 
   events() {
     this.setLoadedClass();
     this.focalImages();
-    this.setTruncationClass();
     setTimeout(() => this.getDatePickerHeight(), 1000);
 
     window.addEventListener("resize", this.getDatePickerHeight.bind(this));
     window.addEventListener("resize", this.setResizeClass.bind(this));
-    window.addEventListener("resize", this.setTruncationClass.bind(this));
   }
 
   getDatePickerHeight() {
@@ -90,25 +79,6 @@ class Main {
   // adding class after loading content
   setLoadedClass() {
     this.block.classList.add(this.modifier.loaded);
-  }
-
-  // set class for truncation product card description
-  setTruncationClass() {
-    if (!this.excerpts.length) return false;
-
-    const styles = window.getComputedStyle(this.excerpts[0]),
-          paddingTop = parseInt(styles.getPropertyValue(this.cssProp.paddingTop)),
-          paddingBottom = parseInt(styles.getPropertyValue(this.cssProp.paddingBottom)),
-          maxHeight = parseInt(styles.getPropertyValue(this.cssProp.maxHeight)),
-          minHeight = maxHeight / 2 + paddingBottom + paddingTop;
-
-    this.excerpts.forEach(excerpt => {
-      const height = excerpt.getBoundingClientRect().height
-
-      height > minHeight
-        ? excerpt.classList.add(this.modifier.truncated)
-        : excerpt.classList.remove(this.modifier.truncated)
-    })
   }
 
   // change focus positioning of image

--- a/assets/product-card.css
+++ b/assets/product-card.css
@@ -58,38 +58,10 @@
 .product-card__description {
   padding: 4px 0 8px;
   flex-grow: 0;
-  overflow: hidden;
-  max-height: 130px;
 }
 
 .product-card__description:last-child {
   padding-bottom: 0;
-}
-
-.product-card__description.truncated {
-  position: relative;
-  flex-grow: 1;
-}
-
-.product-card__description.truncated + .product-card__price-info {
-  flex-grow: 0;
-}
-
-.product-card__description.truncated:after {
-  content: "";
-  display: block;
-  width: 100%;
-  height: 60px;
-  position: absolute;
-  bottom: 0;
-  left: 0;
-}
-
-.product-card__meta .product-card__description dt,
-.product-card__meta .product-card__description dd,
-.product-card__meta .product-card__description li,
-.product-card__meta .product-card__description li li {
-  font-size: inherit;
 }
 
 .product-card__price-info {
@@ -147,10 +119,6 @@ bq-product-availability[visible="true"] {
   background: var(--color-image-placeholder, #0B1A2626);
 }
 
-.palette-one .product-card__description.truncated:after {
-  background: linear-gradient(to top, var(--background-primary, #FFFFFF) 0%, var(--background-primary, #FFFFFF) 30%, var(--background-primary-00, #FFFFFF00) 100%);
-}
-
 .palette-one .product-card__price-info {
   color: var(--color-primary, #0B1A26);
 }
@@ -174,10 +142,6 @@ bq-product-availability[visible="true"] {
   background: var(--color-image-placeholder-2, #FFFFFF47);
 }
 
-.palette-two .product-card__description.truncated:after {
-  background: linear-gradient(to top, var(--background-primary-2, #0B1A26) 0%, var(--background-primary-2, #0B1A26) 30%, var(--background-primary-2-00, #0B1A2600) 100%);
-}
-
 .palette-two .product-card__price-info {
   color: var(--color-primary-2, #FFFFFF);
 }
@@ -199,10 +163,6 @@ bq-product-availability[visible="true"] {
 
 .palette-three .product-card__vision.no-image {
   background: var(--color-image-placeholder-3, #0B1A2626);
-}
-
-.palette-three .product-card__description.truncated:after {
-  background: linear-gradient(to top, var(--background-primary-3, #F4B841) 0%, var(--background-primary-3, #F4B841) 30%, var(--background-primary-3-00, #F4B84100) 100%);
 }
 
 .palette-three .product-card__price-info {

--- a/snippets/product-card.liquid
+++ b/snippets/product-card.liquid
@@ -49,7 +49,7 @@
   {%- assign id      = product.id -%}
   {%- assign url     = product.url -%}
   {%- assign name    = product.name -%}
-  {%- assign excerpt = product.description -%}
+  {%- assign excerpt = product.excerpt -%}
   {%- assign price   = product | product_price -%}
   {%- assign period  = product | product_price_label -%}
 
@@ -101,7 +101,7 @@
     </h3>
 
     {%- if excerpt != blank and show_excerpt -%}
-      <div class="product-card__description bq-content rx-content">{{- excerpt -}}</div>
+      <div class="product-card__description">{{- excerpt -}}</div>
     {%- endif -%}
 
     {%- if price != blank and period != blank -%}


### PR DESCRIPTION
Due to a new product excerpt field [already available on the production]( https://github.com/booqable/booqable/pull/11138), so all the stuff that temporarily solved the issue of not-so-beautiful product descriptions in product cards, and its stripping html and truncating on the theme side should be removed now.

![Arc_2024-07-30 16-02-02@2x](https://github.com/user-attachments/assets/297ce4aa-0d67-4a22-8d8b-563522fc7c5a)
![Arc_2024-07-30 16-02-42@2x](https://github.com/user-attachments/assets/cc64f526-87e7-4f30-a555-fcca6d54454e)
