### PR TITLE
Fix the pricing layout if a label is too long

### DIFF
--- a/assets/product-card.css
+++ b/assets/product-card.css
@@ -75,6 +75,7 @@
 
 .product-card__price-wrapper {
   display: flex;
+  flex-wrap: wrap;
   align-items: flex-end;
 }
 

--- a/sections/hero.liquid
+++ b/sections/hero.liquid
@@ -67,7 +67,7 @@
       </h1>
 
       <div class="hero__description text-medium bq-content rx-content">
-        {{- custom_description | default: collection.description | default: page_description -}}
+        {{- custom_description | default: collection.description -}}
       </div>
     </div>
   </div>


### PR DESCRIPTION
This PR aims to fix the issue with pricing structure if the label of the pricing is too long

**Before:**
<img width="701" alt="Screenshot 2024-08-02 at 15 06 02" src="https://github.com/user-attachments/assets/45e01f96-55dd-485d-bb4e-93c1232edb8b">


**After:**
![Arc_2024-08-05 13-03-39@2x](https://github.com/user-attachments/assets/c5037b74-e1a1-4ea0-a216-3eae12b02f69)
