### PR TITLE
Implement `Accept invitation` page

### DIFF
--- a/assets/account.css
+++ b/assets/account.css
@@ -205,6 +205,7 @@
   height: calc(100vh - var(--header-height, 130px) - var(--header-transform, 0px));
   transition: all var(--animation-duration, 200ms) var(--transition-function-ease-out);
   padding: 10px;
+  z-index: 1;
   backdrop-filter: blur(5px);
   visibility: hidden;
   opacity: 0;
@@ -284,6 +285,7 @@
   top: 50%;
   transform: translate(0, -50%);
   padding: 0 5px;
+  border-radius: var(--border-radius-rounded, 0);
   background:  var(--color-red-light, #F5CFCF);
   color: var(--color-red, #C23434);
   pointer-events: none;

--- a/sections/accept-invitation-form.liquid
+++ b/sections/accept-invitation-form.liquid
@@ -1,15 +1,16 @@
 {{ "account.css" | asset_url | stylesheet_tag }}
 
-{%- assign title                 = section.settings.title -%}
-{%- assign description           = section.settings.description -%}
-{%- assign password_label        = section.settings.password_label | default: 'New password' -%}
-{%- assign password_confirmation = section.settings.password_confirmation | default: 'Confirm new password' -%}
-{%- assign button_label          = section.settings.button_label | default: 'Change my password' -%}
+{%- assign button_label          = section.settings.button_label | default: "Accept invite" -%}
 {%- assign color_palette         = section.settings.color_palette -%}
-{%- assign padding_top           = section.settings.padding_top -%}
 {%- assign padding_bottom        = section.settings.padding_bottom -%}
-{%- assign padding_top_mobile    = section.settings.padding_top_mobile -%}
 {%- assign padding_bottom_mobile = section.settings.padding_bottom_mobile -%}
+{%- assign padding_top           = section.settings.padding_top -%}
+{%- assign padding_top_mobile    = section.settings.padding_top_mobile -%}
+{%- assign password_label        = section.settings.password_label | default: "New password" -%}
+{%- assign password_confirmation = section.settings.password_confirmation | default: "Confirm new password" -%}
+{%- assign please_enter_password = section.settings.please_enter_password -%}
+{%- assign success_link_label    = section.settings.success_link_label -%}
+{%- assign you_are_invited       = section.settings.you_are_invited -%}
 
 {% comment %} CSS variables start {% endcomment %}
 {%- capture variables -%}
@@ -56,35 +57,51 @@
   style="{{- variables | escape -}}"
 >
   <div class="account__container container">
-    <h3 class="account__title text-center">
-      {{- title | default: 'Change your password' -}}
-    </h3>
-
-    {%- if description != blank -%}
-      <div class="account__divider">
-        {{- description -}}
-      </div>
+    {%- if alert -%}
+      <div class="account__alert account__alert--danger">{{ alert }}</div>
     {%- endif -%}
 
-    {%- form 'edit_password' -%}
-      {%- render 'form-password-session-pages',
-          form: form,
-          form_name: "edit_password",
-          password_label: password_label,
-          password_confirmation_label: password_confirmation,
-          button_label: button_label
-      -%}
-    {%- endform -%}
+    {%- if notice -%}
+      <div class="account__alert account__alert--info">{{ notice }}</div>
+    {%- endif -%}
+
+    {%- if success_link_url -%}
+      <a href="{{ success_link_url }}">{{ success_link_label }}</a>
+    {%- endif -%}
+
+    {%- unless hide_form -%}
+      {% if you_are_invited or please_enter_password %}
+        <div class="account__alert account__alert--info">
+          {% if you_are_invited %}
+            <p>{{ you_are_invited }}</p>
+          {% endif %}
+
+          {% if please_enter_password %}
+            <p>{{ please_enter_password }}</p>
+          {% endif %}
+        </div>
+      {% endif %}
+
+      {%- form 'accept_invitation' -%}
+        {%- render 'form-password-session-pages',
+            form: form,
+            form_name: "accept_invitation",
+            password_label: password_label,
+            password_confirmation_label: password_confirmation,
+            button_label: button_label
+        -%}
+      {%- endform -%}
+    {%- endunless -%}
   </div>
 </div>
 
 {% schema %}
   {
-    "name": "Edit password form",
+    "name": "Accept invitation form",
     "important": true,
     "unique": true,
     "tag": "section",
-    "templates": ["edit-password"],
+    "templates": ["accept-invitation"],
     "settings": [
       {
         "type": "header",
@@ -112,13 +129,13 @@
       },
       {
         "type": "text",
-        "id": "title",
-        "label": "Title"
+        "id": "you_are_invited",
+        "label": "Accept invitation title"
       },
       {
         "type": "text",
-        "id": "description",
-        "label": "Description"
+        "id": "please_enter_password",
+        "label": "Password instructions"
       },
       {
         "type": "text",
@@ -129,6 +146,11 @@
         "type": "text",
         "id": "password_confirmation",
         "label": "Password confirmation label"
+      },
+      {
+        "type": "text",
+        "id": "success_link_label",
+        "label": "Success link label"
       },
       {
         "type": "header",

--- a/sections/login-form.liquid
+++ b/sections/login-form.liquid
@@ -132,7 +132,6 @@
           type="submit"
           class="account__button button button--primary button--large"
           name="commit"
-          data-disable-with="Log in"
         >
           {{- button_login_label | default: "Log in" -}}
         </button>

--- a/sections/register-form.liquid
+++ b/sections/register-form.liquid
@@ -121,7 +121,6 @@
           value="{{- form.email -}}"
           placeholder=" "
           class="account-fieldset__input"
-          autofocus="autofocus"
           autocomplete="email"
           type="email"
           name="user[email]"

--- a/sections/register-form.liquid
+++ b/sections/register-form.liquid
@@ -7,8 +7,8 @@
 {%- assign button_signup_label                      = section.settings.button_signup_label -%}
 {%- assign name_label                               = section.settings.name_label -%}
 {%- assign email_label                              = section.settings.email_label -%}
-{%- assign password_label                           = section.settings.password_label -%}
-{%- assign password_confirmation_label              = section.settings.password_confirmation_label -%}
+{%- assign password_label                           = section.settings.password_label | default: "Password" -%}
+{%- assign password_confirmation_label              = section.settings.password_confirmation_label | default: "Password confirmation" -%}
 {%- assign account_type_label                       = section.settings.account_type_label -%}
 {%- assign private_label                            = section.settings.private_label -%}
 {%- assign company_label                            = section.settings.company_label -%}
@@ -132,49 +132,13 @@
         </div>
       </div>
 
-      <div class="account-fieldset__block{% if form.errors.password %} account-fieldset--error{%- endif -%}">
-        <label for="user_password" class="account-fieldset__label">
-          {{- password_label | default: "Password" -}}
-
-          <span class="account-fieldset__label-backlight">
-            {{- password_label | default: "Password" -}}
-          </span>
-        </label>
-
-        <input
-          placeholder=" "
-          class="account-fieldset__input"
-          autocomplete="new-password"
-          type="password"
-          name="user[password]"
-          id="user_password">
-
-        <div class="account__error-message">
-          {{- form.errors.password -}}
-        </div>
-      </div>
-
-      <div class="account-fieldset__block{% if form.errors.password_confirmation %} account-fieldset--error{%- endif -%}">
-        <label for="user_password_confirmation" class="account-fieldset__label">
-          {{- password_confirmation_label | default: "Password confirmation" -}}
-
-          <span class="account-fieldset__label-backlight">
-            {{- password_confirmation_label | default: "Password confirmation" -}}
-          </span>
-        </label>
-
-        <input
-          placeholder=" "
-          class="account-fieldset__input"
-          autocomplete="new-password"
-          type="password"
-          name="user[password_confirmation]"
-          id="user_password_confirmation">
-
-        <div class="account__error-message">
-          {{- form.errors.password_confirmation -}}
-        </div>
-      </div>
+      {%- render 'form-password-session-pages',
+          form: form,
+          form_name: "register",
+          password_label: password_label,
+          password_confirmation_label: password_confirmation_label,
+          button_label: nil
+      -%}
 
       <div class="account__type account__divider{% if form.errors.customer %} account-fieldset--error{%- endif -%}">
         <span class="account-fieldset__static-label">

--- a/sections/register-form.liquid
+++ b/sections/register-form.liquid
@@ -229,7 +229,6 @@
         type="submit"
         class="account__button button button--primary button--large"
         name="commit"
-        data-disable-with="Sign up"
       >
         {{- button_signup_label | default: "Sign up" -}}
       </button>

--- a/sections/reset-password-form.liquid
+++ b/sections/reset-password-form.liquid
@@ -98,7 +98,6 @@
         type="submit"
         class="account__button button button--primary button--large"
         name="commit"
-        data-disable-with="Send me reset password instructions"
       >
         {{- reset_password_label | default: "Reset password" -}}
       </button>

--- a/snippets/form-password-session-pages.liquid
+++ b/snippets/form-password-session-pages.liquid
@@ -1,6 +1,6 @@
 {% comment %}
 
-  This snippet is using for rendering the form on Edit password, Accept invitation and Reset password pages.
+  This snippet is using for rendering the form password inputs on Edit password, Accept invitation and Register pages.
 
   form_name - "string" optional, the name of the form
   password_label - "string" required, the label of the first field

--- a/snippets/form-password-session-pages.liquid
+++ b/snippets/form-password-session-pages.liquid
@@ -1,6 +1,6 @@
 {% comment %}
 
-  This snippet is using for rendering the form password inputs on Edit password, Accept invitation and Register pages.
+  This snippet is using for rendering the form input password fields on Edit password, Accept invitation and Register pages.
 
   form_name - "string" optional, the name of the form
   password_label - "string" required, the label of the first field

--- a/snippets/form-password-session-pages.liquid
+++ b/snippets/form-password-session-pages.liquid
@@ -1,0 +1,87 @@
+{% comment %}
+
+  This snippet is using for rendering the form on Edit password, Accept invitation and Reset password pages.
+
+  form_name - "string" optional, the name of the form
+  password_label - "string" required, the label of the first field
+  password_confirmation_label - "string" required, the label of the second field
+  button_label - "string" required
+
+  Usage:
+
+  {%- render 'form-password-session-pages',
+      form: form,
+      form_name: your_id,
+      password_label: your_id,
+      password_confirmation_label: your_id,
+      button_label: your_id
+  -%}
+
+{% endcomment %}
+
+{%- if password_label != blank -%}
+  <div class="account-fieldset__block{% unless form_name == "register" %} account__divider--small{% endunless %}{% if form.errors.password %} account-fieldset--error{%- endif -%}">
+    <label for="user_password" class="account-fieldset__label">
+      {{- password_label -}}
+
+      <span class="account-fieldset__label-backlight">
+        {{- password_label -}}
+      </span>
+    </label>
+
+    <input
+      value="{{- form.password -}}"
+      placeholder=" "
+      class="account-fieldset__input"
+      {% unless form_name == "register" %}
+        autofocus="autofocus"
+      {% endunless %}
+      autocomplete="new-password"
+      type="password"
+      name="user[password]"
+      id="user_password">
+
+    <div class="account__error-message">
+      {{- form.errors.password -}}
+    </div>
+  </div>
+{%- endif -%}
+
+{%- if password_confirmation_label != blank -%}
+  <div class="account-fieldset__block{% if form.errors.password_confirmation %} account-fieldset--error{%- endif -%}">
+    <label for="user_password_confirmation" class="account-fieldset__label">
+      {{- password_confirmation_label -}}
+
+      <span class="account-fieldset__label-backlight">
+        {{- password_confirmation_label -}}
+      </span>
+    </label>
+
+    <input
+      value="{{- form.password_confirmation -}}"
+      placeholder=" "
+      class="account-fieldset__input"
+      autocomplete="new-password"
+      type="password"
+      name="user[password_confirmation]"
+      id="user_password_confirmation">
+
+    <div class="account__error-message">
+      {{- form.errors.password_confirmation -}}
+    </div>
+  </div>
+{%- endif -%}
+
+{%- if button_label != blank -%}
+  <div class="actions">
+    <button
+      type="submit"
+      class="account__button button button--primary button--large"
+      name="commit"
+      data-disable-with="{{- button_label -}}"
+    >
+      {{- button_label -}}
+    </button>
+  </div>
+{%- endif -%}
+

--- a/snippets/form-password-session-pages.liquid
+++ b/snippets/form-password-session-pages.liquid
@@ -78,7 +78,6 @@
       type="submit"
       class="account__button button button--primary button--large"
       name="commit"
-      data-disable-with="{{- button_label -}}"
     >
       {{- button_label -}}
     </button>

--- a/templates/accept-invitation.json
+++ b/templates/accept-invitation.json
@@ -1,0 +1,24 @@
+{
+  "name": "Accept invitation",
+  "layout": "session",
+  "sections": {
+    "accept-invitation-form": {
+      "type": "accept-invitation-form",
+      "blocks": {},
+      "settings": {
+        "color_palette": "one",
+        "padding_bottom": "large",
+        "padding_bottom_mobile": "large",
+        "padding_top": "large",
+        "padding_top_mobile": "large",
+        "please_enter_password": "If you want to continue, please enter your password below.",
+        "success_link_label": "Continue to the store",
+        "you_are_invited": "You've been invited to create an account."
+      }
+    }
+  },
+  "order": ["accept-invitation-form"],
+  "editor_settings": {
+    "visible_only_when": ["user_authentication_enabled"]
+  }
+}

--- a/templates/romance/accept-invitation.json
+++ b/templates/romance/accept-invitation.json
@@ -1,0 +1,24 @@
+{
+  "name": "Accept invitation",
+  "layout": "session",
+  "sections": {
+    "accept-invitation-form": {
+      "type": "accept-invitation-form",
+      "blocks": {},
+      "settings": {
+        "color_palette": "two",
+        "padding_bottom": "large",
+        "padding_bottom_mobile": "large",
+        "padding_top": "large",
+        "padding_top_mobile": "large",
+        "please_enter_password": "If you want to continue, please enter your password below.",
+        "success_link_label": "Continue to the store",
+        "you_are_invited": "You've been invited to create an account."
+      }
+    }
+  },
+  "order": ["accept-invitation-form"],
+  "editor_settings": {
+    "visible_only_when": ["user_authentication_enabled"]
+  }
+}

--- a/templates/vogue/accept-invitation.json
+++ b/templates/vogue/accept-invitation.json
@@ -1,0 +1,24 @@
+{
+  "name": "Accept invitation",
+  "layout": "session",
+  "sections": {
+    "accept-invitation-form": {
+      "type": "accept-invitation-form",
+      "blocks": {},
+      "settings": {
+        "color_palette": "two",
+        "padding_bottom": "large",
+        "padding_bottom_mobile": "large",
+        "padding_top": "large",
+        "padding_top_mobile": "large",
+        "please_enter_password": "If you want to continue, please enter your password below.",
+        "success_link_label": "Continue to the store",
+        "you_are_invited": "You've been invited to create an account."
+      }
+    }
+  },
+  "order": ["accept-invitation-form"],
+  "editor_settings": {
+    "visible_only_when": ["user_authentication_enabled"]
+  }
+}


### PR DESCRIPTION
This PR goal is to implement a new `Accept invitation` page into all theme variants, and slightly refactor the code: 
remove `data-disable-with` attribute from everywhere, move form input password fields code to snippet.

Since this feature doesn't work on the production yet I can't provide screenshots (((