### PR TITLE
Allow meta image and alt tag to be customizable from drops

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -18,6 +18,8 @@
     {% render 'page-metadata',
       page_title: page_title,
       page_description: page_description,
+      page_meta_image_url: page_meta_image_url,
+      page_meta_image_alt: page_meta_image_alt,
       product: product,
       shop: shop
     %}

--- a/snippets/page-metadata.liquid
+++ b/snippets/page-metadata.liquid
@@ -29,14 +29,15 @@
 {% else %}
   <meta property="og:type" content="product">
   <meta property="og:url" content="{{ product.url }}">
+{% endif %}
 
-  {% assign image = product.images.first %}
+{% if page_meta_image_url != blank %}
+  <meta property="og:image" content="{{ page_meta_image_url }}">
+  <meta property="og:image:secure_url" content="{{ page_meta_image_url }}">
+  <meta name="twitter:image" content="{{ page_meta_image_url }}">
 
-  {% if image.url != blank %}
-    <meta property="og:image" content="{{ image.url | image_url }}">
-    <meta property="og:image:secure_url" content="{{ image.url | image_url }}">
-    <meta property="og:image:alt" content="{{ product.name }}">
-    <meta name="twitter:image" content="{{ image.url | image_url }}">
-    <meta name="twitter:image:alt" content="{{ product.name }}">
+  {% if page_meta_image_alt != blank %}
+    <meta property="og:image:alt" content="{{ page_meta_image_alt }}">
+    <meta name="twitter:image:alt" content="{{ page_meta_image_alt }}">
   {% endif %}
 {% endif %}


### PR DESCRIPTION
Allows custom meta image and meta image alt tag.

https://linear.app/booqable/issue/GUA-783/use-company-logo-when-sharing-website-on-social-media