### PR TITLE
Fix the mini cart positioning and height for the menu bottom mode on small screens

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -171,7 +171,7 @@ body > * {
 }
 
 .preview-bar__container {
-  z-index: 1002 !important;
+  z-index: 10000000 !important;
 }
 
 h1,
@@ -674,21 +674,92 @@ div[data-tid="Modal actions"] button {
 
 @media (min-width: 576px) {
   div[data-tippy-root]:has([data-tid="Mini cart"]) {
-    position: fixed !important;
     top: var(--header-height) !important;
     right: var(--horizontal-padding) !important;
     transform: translate(0, 0) !important;
     transition: top var(--animation-duration, 200ms) var(--transition-function-ease-in-out);
   }
 
-  .scrolled-down div[data-tippy-root]:has([data-tid="Mini cart"]) {
+  div[data-tippy-root] div[data-tid="Mini cart"] {
+    height: auto;
+    max-height: calc(100vh - var(--header-height));
+  }
+
+  div[data-tid="Mini cart"] div[class*="Summary"] div[class*="Services"] {
+    max-height: 84px;
+  }
+
+  body:has(.header--sticky) div[data-tippy-root]:has([data-tid="Mini cart"]) {
+    position: fixed !important;
+  }
+
+  .scrolled-down:has(.header--sticky) div[data-tippy-root]:has([data-tid="Mini cart"]) {
     top: calc(var(--header-height) + var(--header-transform, 0)) !important;
+  }
+
+  body:has(.preview-bar__container) div[data-tippy-root]:has([data-tid="Mini cart"]) {
+    top: calc(var(--header-height) + var(--preview-height, 0)) !important;
+  }
+
+  body:has(.preview-bar__container) div[data-tippy-root] [data-tid="Mini cart"] {
+    max-height: calc(100vh - var(--header-height) - var(--preview-height, 0) / 2);
+  }
+
+  body:has(.preview-bar__container):has(.header--sticky) div[data-tippy-root]:has([data-tid="Mini cart"]) {
+    top: calc(var(--header-height)) !important;
+  }
+
+  .scrolled-down:has(.preview-bar__container):has(.header--sticky) div[data-tippy-root]:has([data-tid="Mini cart"]) {
+    top: calc(var(--header-height) + var(--header-transform, 0)) !important;
+  }
+}
+
+@media (min-width: 1100px) {
+  body:has(.header-menu-bottom) div[data-tippy-root]:has([data-tid="Mini cart"]) {
+    top: calc(var(--header-height) - var(--menu-position)) !important;
+  }
+
+  body:has(.header-menu-bottom) div[data-tippy-root] div[data-tid="Mini cart"] {
+    max-height: calc(100vh - var(--header-height) + var(--menu-position));
+  }
+
+  .scrolled-down:has(.header--sticky):has(.header-menu-bottom) div[data-tippy-root]:has([data-tid="Mini cart"]) {
+    top: calc(var(--header-height) - var(--menu-position) + var(--header-transform, 0)) !important;
+  }
+
+  body:has(.preview-bar__container):has(.header-menu-bottom) div[data-tippy-root]:has([data-tid="Mini cart"]) {
+    top: calc(var(--header-height) - var(--menu-position) + var(--preview-height, 0)) !important;
+  }
+  body:has(.preview-bar__container):has(.header-menu-bottom) div[data-tippy-root] [data-tid="Mini cart"] {
+    max-height: calc(100vh - var(--header-height) + var(--menu-position) - var(--preview-height, 0) / 2);
+  }
+
+  body:has(.preview-bar__container):has(.header--sticky) div[data-tippy-root]:has([data-tid="Mini cart"]) {
+    top: calc(var(--header-height)) !important;
+  }
+
+  body:has(.preview-bar__container):has(.header--sticky):has(.header-menu-bottom) div[data-tippy-root]:has([data-tid="Mini cart"]) {
+    top: calc(var(--header-height) - var(--menu-position)) !important;
+  }
+
+  .scrolled-down:has(.preview-bar__container):has(.header--sticky) div[data-tippy-root]:has([data-tid="Mini cart"]) {
+    top: calc(var(--header-height) + var(--header-transform, 0)) !important;
+  }
+
+  .scrolled-down:has(.preview-bar__container):has(.header--sticky):has(.header-menu-bottom) div[data-tippy-root]:has([data-tid="Mini cart"]) {
+    top: calc(var(--header-height) - var(--menu-position) + var(--header-transform, 0)) !important;
   }
 }
 
 @media (min-width: 1280px) {
   div[data-tippy-root]:has([data-tid="Mini cart"]) {
     right: calc(50% - var(--max-width) / 2 + var(--horizontal-padding)) !important;
+  }
+}
+
+@media (min-height: 964px) {
+  div[data-tid="Mini cart"] div[class*="Summary"] div[class*="Services"] {
+    max-height: none;
   }
 }
 

--- a/assets/header.js
+++ b/assets/header.js
@@ -8,7 +8,7 @@ class Header {
       view: ".preview-bar__container",
       headerNav: ".header__nav-wrapper",
       menu: ".menu",
-      menuItem: ".menu__item",
+      menuItem: ".menu__list",
       menuDrop: ".has-dropdown",
       menuBottom: ".header-menu-bottom",
       menuOpener: "#mobile-menu-opener",


### PR DESCRIPTION
The customer complains that the shopping cart doesn't look right on his website. Certainly, from his browser - Chrome. And he has to zoom out to 67% to be able to continue with the checkout.

It happens because he uses the `Sticky header` and `Menu bellow` header options and at the same time the menu has a lot of the first-level items, so the header is too tall because of that. On the other hand, the mini-cart is positioned right below the header and has hardcoded values of height and width, therefore the `Checkout` button is below the fold and never can be available for users.

Therefore, the purpose of this PR is to move the mini cart to the top a bit closer to the cart icon in the `Menu below` mode and adjust its height a little bit, so that the `Checkout` and `View cart` buttons are available on all screen resolutions.

Before:
<img width="1242" alt="image(100000)" src="https://github.com/user-attachments/assets/eef0dff0-687b-42df-8501-98df6c7c5754">
<img width="1437" alt="image(100001)" src="https://github.com/user-attachments/assets/d72ab1cc-1ff7-443a-bb09-8c63bce8aed4">


After:

![Arc 2024-10-17 14 34 19](https://github.com/user-attachments/assets/35c8ea8f-c878-41fc-a566-d90eb9ae03d9)
