### PR TITLE
Remove the full width content feature in Images section

### DIFF
--- a/assets/images.css
+++ b/assets/images.css
@@ -28,11 +28,6 @@
   align-items: var(--text-align-items-mobile, flex-start);
   text-align: var(--text-align-mobile, left);
   margin: 0 var(--margin-right-mobile) 0 var(--margin-left-mobile);
-  max-width: 600px;
-}
-
-.images__text-area.images__text-area--full-width {
-  max-width: none;
 }
 
 .images__text-area.images__text-area--color {

--- a/sections/images.liquid
+++ b/sections/images.liquid
@@ -128,7 +128,6 @@
             {%- assign tag                  = block.settings.tag -%}
             {%- assign title                = block.settings.title -%}
             {%- assign description          = block.settings.description -%}
-            {%- assign full_width_content   = block.settings.full_width_content -%}
             {%- assign button_1             = block.settings.button_1 -%}
             {%- assign button_url_1         = block.settings.button_url_1 -%}
             {%- assign button_2             = block.settings.button_2 -%}
@@ -327,7 +326,7 @@
                     class="images__container container{% if padding_top != blank or padding_top_mobile != blank %} images__container--padding-top{% endif %}{% if padding_bottom != blank or padding_bottom_mobile != blank %} images__container--padding-bottom{% endif %}"
                     style="{{- text_variables | escape -}}"
                   >
-                    <div class="images__text-area{% if full_width_content %} images__text-area--full-width{% endif %}{% if show_overlay %} images__text-area--color{%- endif -%}">
+                    <div class="images__text-area{% if show_overlay %} images__text-area--color{%- endif -%}">
                       <div class="images__content">
                         {%- if tag != blank -%}
                           <strong class="images__tag tagline">{{- tag -}}</strong>
@@ -527,12 +526,6 @@
             "id": "description",
             "label": "Description",
             "default": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros elementum tristique."
-          },
-          {
-            "type": "checkbox",
-            "id": "full_width_content",
-            "label": "Full-width text content",
-            "default": true
           },
           {
             "type": "header",

--- a/templates/apex/index.json
+++ b/templates/apex/index.json
@@ -12,7 +12,6 @@
             "button_url_1": "booqable://products/",
             "button_url_2": "booqable://root/",
             "description": "",
-            "full_width_content": true,
             "image": "booqable://assets/image-apex-hero.jpg",
             "image_mobile": "",
             "overlay_background": "#0B1A26",

--- a/templates/around/index.json
+++ b/templates/around/index.json
@@ -12,7 +12,6 @@
             "button_url_1": "booqable://products/",
             "button_url_2": "booqable://root/",
             "description": "<p>Take the stress out of traveling with your baby,<br>Rent a stroller for the duration of your vacation.</p>",
-            "full_width_content": true,
             "image": "booqable://assets/image-around-hero.jpg",
             "image_mobile": "",
             "overlay_background": "#131314",

--- a/templates/celebrate/index.json
+++ b/templates/celebrate/index.json
@@ -12,7 +12,6 @@
             "button_url_1": "booqable://products/",
             "button_url_2": "booqable://root/",
             "description": "",
-            "full_width_content": true,
             "image": "booqable://assets/image-celebrate-hero.jpg",
             "image_mobile": "",
             "overlay_background": "#0B1A26",

--- a/templates/charge/index.json
+++ b/templates/charge/index.json
@@ -12,7 +12,6 @@
             "button_url_1": "booqable://products/",
             "button_url_2": "booqable://root/",
             "description": "<p>Rent your e-bike from EcoRide and prepare to start your adventure</p>",
-            "full_width_content": true,
             "image": "booqable://assets/image-charge-hero.jpg",
             "image_mobile": "",
             "overlay_background": "#131314",

--- a/templates/chic/index.json
+++ b/templates/chic/index.json
@@ -12,7 +12,6 @@
             "button_url_1": "booqable://products/",
             "button_url_2": "booqable://root/",
             "description": "<p>Luxury furniture delivered to your door for days, </p>\n<p>weeks, or months. It's up to you to style your home.</p>",
-            "full_width_content": true,
             "image": "booqable://assets/image-chic-hero.jpg",
             "image_mobile": "",
             "overlay_background": "#131314",

--- a/templates/coastal/index.json
+++ b/templates/coastal/index.json
@@ -12,7 +12,6 @@
             "button_url_1": "booqable://products/",
             "button_url_2": null,
             "description": "",
-            "full_width_content": true,
             "image": "booqable://assets/image-coastal-hero.jpg",
             "image_mobile": "",
             "overlay_background": "#131314",

--- a/templates/connect/index.json
+++ b/templates/connect/index.json
@@ -12,7 +12,6 @@
             "button_url_1": "booqable://products/",
             "button_url_2": "booqable://root/",
             "description": "<p>Superfast, low-latency internet anywhere</p>",
-            "full_width_content": true,
             "image": "booqable://assets/image-connect-hero.jpg",
             "image_mobile": "",
             "overlay_background": "#131314",

--- a/templates/construct/index.json
+++ b/templates/construct/index.json
@@ -12,7 +12,6 @@
             "button_url_1": "booqable://products/",
             "button_url_2": "booqable://root/",
             "description": "Empower your construction endeavors with our<br> vast inventory of premium equipment rentals.",
-            "full_width_content": true,
             "image": "booqable://assets/image-tough-hero.jpg",
             "image_mobile": "booqable://assets/image-tough-hero-mobile.jpg",
             "overlay_background": "#0B1A26",

--- a/templates/endure/index.json
+++ b/templates/endure/index.json
@@ -12,7 +12,6 @@
             "button_url_1": "booqable://collections/mountain-bikes",
             "button_url_2": "booqable://root/",
             "description": "<p>Explore the trails </p>\n<p>with our selection of mountain bikes</p>\n<p>and accessories</p>",
-            "full_width_content": true,
             "image": "booqable://assets/image-endure-hero.jpg",
             "image_mobile": null,
             "overlay_background": "#131314",

--- a/templates/focus/index.json
+++ b/templates/focus/index.json
@@ -12,7 +12,6 @@
             "button_url_1": "booqable://collections/",
             "button_url_2": null,
             "description": "<p>Now available to rent!</p>",
-            "full_width_content": true,
             "image": "booqable://assets/image-focus-hero.jpg",
             "image_mobile": "",
             "overlay_background": "#000000",

--- a/templates/move/index.json
+++ b/templates/move/index.json
@@ -12,7 +12,6 @@
             "button_url_1": "booqable://products/",
             "button_url_2": null,
             "description": "",
-            "full_width_content": true,
             "image": "booqable://assets/image-move-hero.jpg",
             "image_mobile": "",
             "overlay_background": "#131314",

--- a/templates/radical/index.json
+++ b/templates/radical/index.json
@@ -12,7 +12,6 @@
             "button_url_1": "booqable://products/",
             "button_url_2": "booqable://root/",
             "description": "<p>Unlock your creative potential and seize every moment in<br>stunning detail with our extensive selection of camera rentals.</p>",
-            "full_width_content": true,
             "image": "booqable://assets/image-radical-hero.jpg",
             "image_mobile": "",
             "overlay_background": "#131314",

--- a/templates/romance/index.json
+++ b/templates/romance/index.json
@@ -12,7 +12,6 @@
             "button_url_1": "booqable://products/",
             "button_url_2": "booqable://root/",
             "description": "Transform your event into an unforgettable experience<br>with our extensive selection of high-quality decor rentals.",
-            "full_width_content": true,
             "image": "booqable://assets/image-romantic-hero.jpeg",
             "image_mobile": "",
             "overlay_background": "#231905",

--- a/templates/stellar/index.json
+++ b/templates/stellar/index.json
@@ -12,7 +12,6 @@
             "button_url_1": "booqable://products/",
             "button_url_2": "booqable://root/",
             "description": "",
-            "full_width_content": true,
             "image": "booqable://assets/image-stellar-hero.jpg",
             "image_mobile": "",
             "overlay_background": "#131314",

--- a/templates/utility/index.json
+++ b/templates/utility/index.json
@@ -12,7 +12,6 @@
             "button_url_1": "booqable://products/",
             "button_url_2": null,
             "description": "",
-            "full_width_content": true,
             "image": "booqable://assets/image-utility-hero.jpg",
             "image_mobile": "",
             "overlay_background": "#131314",

--- a/templates/vogue/index.json
+++ b/templates/vogue/index.json
@@ -12,7 +12,6 @@
             "button_url_1": "booqable://products/",
             "button_url_2": "booqable://root/",
             "description": "Unleash your inner fashionista with an<br/>array of stunning rental options for every occasion.",
-            "full_width_content": true,
             "image": "booqable://assets/image-fashion-hero.png",
             "image_mobile": "",
             "overlay_background": "#222222",

--- a/templates/waverunner/index.json
+++ b/templates/waverunner/index.json
@@ -12,7 +12,6 @@
             "button_url_1": "booqable://products/",
             "button_url_2": "booqable://root/",
             "description": "<p>Dive into the ultimate surf adventure with our diverse range <br>of high-quality surfboard rentals, offering the perfect boards </p>",
-            "full_width_content": true,
             "image": "booqable://assets/image-waverunner-hero.jpg",
             "image_mobile": "",
             "overlay_background": "#131314",


### PR DESCRIPTION
We got an issue when the content of the Hero section was set to not be full width by default after introducing a new option. Yesterday I tried to fix it by changing the default value to true of the new option in schema but apparently, it didn’t work.

So this PR aims to revert this option temporarily