### PR TITLE
Adjust the Weglot dropdown text

### DIFF
--- a/assets/footer.css
+++ b/assets/footer.css
@@ -147,6 +147,7 @@
 }
 
 #section-footer .footer__app .weglot-widget__item {
+  white-space: nowrap;
   transition: all var(--animation-duration) var(--transition-function-ease-in-out);
 }
 

--- a/assets/header.css
+++ b/assets/header.css
@@ -309,6 +309,7 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
 }
 
 #section-header .app-mobile .weglot-widget__item {
+  white-space: nowrap;
   transition: all var(--animation-duration) var(--transition-function-ease-in-out);
 }
 
@@ -812,6 +813,7 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
   }
 
   #section-header .header__app .weglot-widget__item {
+    white-space: nowrap;
     transition: all var(--animation-duration) var(--transition-function-ease-in-out);
   }
 


### PR DESCRIPTION
This PR aims to fix broken text in the Weglot dropdown

Before:
![Arc 2024-12-30 14 42 04](https://github.com/user-attachments/assets/c79eb8d0-60b0-4fe4-9f57-7da125c4ea36)
![Arc 2024-12-30 14 44 44](https://github.com/user-attachments/assets/44500bea-49a1-4cae-b78f-d9905a67fbb2)


After:
![Arc 2024-12-30 14 42 54](https://github.com/user-attachments/assets/b7f7ee64-4412-4440-8023-bddbf0d54808)
![Arc 2024-12-30 14 44 19](https://github.com/user-attachments/assets/1cedcd1a-7967-42fe-a332-051b8e47820f)

