### PR TITLE
Add automatic `fade out` effect with js for sidebar dropdown if it's taller than parent element

### DIFF
--- a/assets/sidebar.css
+++ b/assets/sidebar.css
@@ -40,7 +40,6 @@
 
 .sidebar__menu > .sidebar__menu-list > .sidebar__menu-item:after {
   content: "";
-  opacity: 0;
   visibility: hidden;
   position: absolute;
   left: 0;
@@ -51,7 +50,6 @@
 
 .sidebar__menu > .sidebar__menu-list > .sidebar__menu-item--expanded:after {
   visibility: visible;
-  opacity: 1;
 }
 
 .sidebar__menu-opener {

--- a/assets/sidebar.css
+++ b/assets/sidebar.css
@@ -24,12 +24,34 @@
   border-bottom: 1px solid transparent;
 }
 
-.sidebar__menu:last-child{
+.sidebar__menu:last-child {
   margin: 0;
 }
 
 .sidebar__menu-item {
   margin: 0 0 16px;
+  overflow: hidden;
+  position: relative;
+}
+
+.sidebar__menu-item:last-child {
+  margin: 0;
+}
+
+.sidebar__menu > .sidebar__menu-list > .sidebar__menu-item:after {
+  content: "";
+  opacity: 0;
+  visibility: hidden;
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  height: 60px;
+}
+
+.sidebar__menu > .sidebar__menu-list > .sidebar__menu-item--expanded:after {
+  visibility: visible;
+  opacity: 1;
 }
 
 .sidebar__menu-opener {
@@ -58,22 +80,15 @@
   width: 2px;
 }
 
-.sidebar__menu-item {
-  overflow: hidden;
-  position: relative;
-}
-
-.sidebar__menu-item:last-child{
-  margin: 0;
-}
-
 .sidebar__menu-wrapper {
   position: relative;
   height: auto;
   pointer-events: none;
   max-height: 0;
   overflow-y: auto;
-  transition: max-height var(--animation-duration, 200ms) var(--transition-function-ease-out);
+  transition-property: max-height;
+  transition-duration: var(--animation-duration, 200ms);
+  transition-timing-function: var(--transition-function-ease-out);
 }
 
 .sidebar__menu-wrapper .sidebar__menu-list {
@@ -143,6 +158,18 @@
   transform: translate(0, 0);
 }
 
+.sidebar__menu-item--expanded:has([id^="side-menu-opener-"]:checked) > .sidebar__menu-wrapper > .sidebar__menu-list > .sidebar__menu-item:last-child {
+  margin-bottom: 50px;
+}
+
+.sidebar__menu-item--expanded:has([id^="side-menu-opener-"]:checked) > .sidebar__menu-wrapper > .sidebar__menu-list > .sidebar__menu-item:last-child .sidebar__menu-item:last-child {
+  margin-bottom: 0;
+}
+
+.sidebar__menu-item--expanded:has([id^="side-menu-opener-"]:checked) > .sidebar__menu-wrapper > .sidebar__menu-list > .sidebar__menu-item:last-child .sidebar__menu-list {
+  padding-bottom: 0;
+}
+
 .palette-one .sidebar__nav-opener {
   border-color: var(--color-border, #0B1A2626);
 }
@@ -176,6 +203,10 @@
 .palette-one .sidebar__menu-opener:active:before,
 .palette-one .sidebar__menu-opener:active:after {
   background: var(--color-outline-active, #F4B841BA);
+}
+
+.palette-one .sidebar__menu > .sidebar__menu-list > .sidebar__menu-item:after {
+  background: linear-gradient(180deg, var(--background-primary-00) 0%, var(--background-primary) 100%);
 }
 
 .palette-two .sidebar__nav-opener {
@@ -213,6 +244,10 @@
   background: var(--color-outline-2-active, #F4B841BA);
 }
 
+.palette-two .sidebar__menu > .sidebar__menu-list > .sidebar__menu-item:after {
+  background: linear-gradient(180deg, var(--background-primary-2-00) 0%, var(--background-primary-2) 100%);
+}
+
 .palette-three .sidebar__nav-opener {
   border-color: var(--color-border-3, #0B1A2626);
 }
@@ -246,6 +281,10 @@
 .palette-three .sidebar__menu-opener:active:before,
 .palette-three .sidebar__menu-opener:active:after {
   background: var(--color-outline-3-active, #0B1A26BA);
+}
+
+.palette-three .sidebar__menu > .sidebar__menu-list > .sidebar__menu-item:after {
+  background: linear-gradient(180deg, var(--background-primary-3-00) 0%, var(--background-primary-3) 100%);
 }
 
 .loaded .sidebar__menu-wrapper {

--- a/assets/sidebar.js
+++ b/assets/sidebar.js
@@ -1,0 +1,68 @@
+class Sidebar {
+  constructor(block) {
+    this.block = block;
+
+    this.selector = {
+      dropdown: ".js-sidebar-menu-dropdown",
+      item: ".js-sidebar-menu-item",
+      list: ".sidebar__menu-list",
+      trigger: "[id*='side-menu-opener-']"
+    }
+
+    this.modifier = {
+      expanded: "sidebar__menu-item--expanded"
+    }
+
+    this.classes = {
+      opener: "sidebar__menu-opener"
+    }
+
+    this.cssProps = {
+      maxHeight: 'max-height',
+      duration: 'transition-duration'
+    }
+  }
+
+  init() {
+    if (!this.block) return false;
+
+    this.events();
+  }
+
+  events() {
+    document.addEventListener("click", this.setGradient.bind(this));
+  }
+
+  setGradient(e) {
+    const target = e.target,
+          parent = target.closest(this.selector.item),
+          isOpener = target.classList.contains(this.classes.opener);
+
+    if (!parent || !isOpener) return false;
+
+    const trigger = parent.querySelector(this.selector.trigger),
+          dropdown = parent.querySelector(this.selector.dropdown),
+          list = dropdown.querySelector(this.selector.list);
+
+    const toggleClass = () => {
+      const dropdownStyles = window.getComputedStyle(dropdown),
+            maxHeight = parseFloat(dropdownStyles.getPropertyValue(this.cssProps.maxHeight)),
+            listHeight = list.getBoundingClientRect().height;
+
+      (listHeight > maxHeight && trigger.checked)
+        ? parent.classList.add(this.modifier.expanded)
+        : parent.classList.remove(this.modifier.expanded)
+    }
+
+    dropdown.addEventListener('transitionend', (e) => {
+      if (e.propertyName !== this.cssProps.maxHeight) return false;
+      toggleClass();
+    })
+  }
+}
+
+const sidebar = new Sidebar(document.querySelector('.sidebar__nav'));
+
+document.addEventListener("readystatechange", (event) => {
+  if (event.target.readyState === "complete") sidebar.init();
+})

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -45,6 +45,7 @@
     <script src="{{ "text-with-image.js" | asset_url }}" defer></script>
     <script src="{{ "header.js" | asset_url }}" defer></script>
     <script src="{{ "carousel.js" | asset_url }}" defer></script>
+    <script src="{{ "sidebar.js" | asset_url }}" defer></script>
 
     {%- if show_mini_cart -%}
       {%- render 'variables-mini-cart', settings: settings, color_palette: "one" -%}

--- a/snippets/sidebar.liquid
+++ b/snippets/sidebar.liquid
@@ -43,14 +43,14 @@
             {%- assign link_index = forloop.index -%}
 
             {%- if link != blank -%}
-              <li class="sidebar__menu-item">
+              <li class="sidebar__menu-item js-sidebar-menu-item">
                 <a href="{{ link.url }}" class="sidebar__menu-link">{{- link.title -}}</a>
 
                 {%- if link.items_count > 0 -%}
                   <input type="checkbox" id="side-menu-opener-{{- link_index -}}-{{ item.id }}" style="display: none;">
                   <label for="side-menu-opener-{{- link_index -}}-{{ item.id }}" class="sidebar__menu-opener"></label>
 
-                  <div class="sidebar__menu-wrapper" style="display: none;">
+                  <div class="sidebar__menu-wrapper js-sidebar-menu-dropdown" style="display: none;">
                     <ul class="sidebar__menu-list">
                       {%- for childlink in link.items -%}
                         {%- assign childlink_index = forloop.index -%}


### PR DESCRIPTION
Currently, we have a limited height of collection items in an expanded state in the sidebar on the collection and search pages. Customers complain that it is not clear that user should scroll down the sidebar to see all items. 
Therefore, this PR aims to add some `fade out` effect at the bottom of the block but if it's taller than the parent element

Before:
https://www.loom.com/share/f170e6516551420099d5758dfb0e9526

After:

![Arc 2025-01-14 19 05 50](https://github.com/user-attachments/assets/f481150b-df4c-4085-859e-8ed31d66936e)
