### PR TITLE
Add the product description placement option for the product page

### DIFF
--- a/sections/product-page.liquid
+++ b/sections/product-page.liquid
@@ -16,6 +16,7 @@
 {%- assign show_thumbnails               = section.settings.show_thumbnails -%}
 {%- assign infinity_scroll               = section.settings.infinity_scroll -%}
 {%- assign color_palette                 = section.settings.color_palette -%}
+{%- assign description_placement         = section.settings.description_placement -%}
 {%- assign padding_top                   = section.settings.padding_top -%}
 {%- assign padding_bottom                = section.settings.padding_bottom -%}
 {%- assign padding_top_mobile            = section.settings.padding_top_mobile -%}
@@ -108,7 +109,7 @@
             {%- endif -%}
           </div>
 
-          {%- if description != blank -%}
+          {%- if description != blank and description_placement == "top" -%}
             <div class="product-main__description bq-content rx-content">
               {{- description -}}
             </div>
@@ -134,6 +135,12 @@
           {%- if message_label != blank -%}
             <div class="product-main__shipping-info">
               <span class="product-main__shipping-label">{{- message_label -}}</span>
+            </div>
+          {%- endif -%}
+
+          {%- if description != blank and description_placement == "bottom" -%}
+            <div class="product-main__description bq-content rx-content">
+              {{- description -}}
             </div>
           {%- endif -%}
       </div>
@@ -183,6 +190,22 @@
           }
         ],
         "default": "one"
+      },
+      {
+        "type": "select",
+        "id": "description_placement",
+        "label": "Product description placement",
+        "options": [
+          {
+            "value": "top",
+            "label": "Top"
+          },
+          {
+            "value": "bottom",
+            "label": "Bottom"
+          }
+        ],
+        "default": "top"
       },
       {
         "type": "header",

--- a/templates/construct/product.json
+++ b/templates/construct/product.json
@@ -21,6 +21,7 @@
         "breadcrumbs_root_label": "",
         "breadcrumbs_root_url": "collections",
         "color_palette": "one",
+        "description_placement": "top",
         "infinity_scroll": true,
         "message_label": "Free shipping over $50",
         "padding_bottom": "small",

--- a/templates/product.json
+++ b/templates/product.json
@@ -21,6 +21,7 @@
         "breadcrumbs_root_label": "",
         "breadcrumbs_root_url": "collections",
         "color_palette": "one",
+        "description_placement": "top",
         "infinity_scroll": true,
         "message_label": "Free shipping over $50",
         "padding_bottom": "small",

--- a/templates/romance/product.json
+++ b/templates/romance/product.json
@@ -21,6 +21,7 @@
         "breadcrumbs_root_label": "",
         "breadcrumbs_root_url": "collections",
         "color_palette": "one",
+        "description_placement": "top",
         "infinity_scroll": true,
         "message_label": "Free shipping over $50",
         "padding_bottom": "small",

--- a/templates/vogue/product.json
+++ b/templates/vogue/product.json
@@ -21,6 +21,7 @@
         "breadcrumbs_root_label": "",
         "breadcrumbs_root_url": "collections",
         "color_palette": "one",
+        "description_placement": "top",
         "infinity_scroll": true,
         "message_label": "Free shipping over $50",
         "padding_bottom": "small",


### PR DESCRIPTION
We've got a request for moving the `Add to cart` button right underneath the price but we can't do that because of at least 2 options (variant, quantity) that the user should choose before adding the product to the cart.

Therefore this PR's purpose is to add a new option "the product description placement: top or bottom". The top option is supposed to be chosen by default which won't change the existing layout.

Before:
![Arc 2025-01-20 13 35 29](https://github.com/user-attachments/assets/9440c342-e443-4a2f-b8a4-5d8f7829fc47)


After:
![Arc 2025-01-20 13 35 00](https://github.com/user-attachments/assets/237f6226-3d56-4652-905a-c7f767f435c9)
