### PR TITLE
Supporting dynamic titles and descriptions from page context

### DIFF
--- a/sections/hero.liquid
+++ b/sections/hero.liquid
@@ -62,11 +62,11 @@
   <div class="hero__container container{% if padding_top != blank or padding_top_mobile != blank %} hero__container--padding-top{% endif %}{% if padding_bottom != blank or padding_bottom_mobile != blank %} hero__container--padding-bottom{%- endif -%}">
     <div class="hero__content">
       <h1 class="hero__title">
-        {{- custom_title | default: collection.title -}}
+        {{- custom_title | default: collection.title | default: page.title | default: cart.title -}}
       </h1>
 
       <div class="hero__description text-medium bq-content rx-content">
-        {{- custom_description | default: collection.description -}}
+        {{- custom_description | default: collection.description | default: page.content -}}
       </div>
     </div>
   </div>

--- a/sections/hero.liquid
+++ b/sections/hero.liquid
@@ -62,11 +62,21 @@
   <div class="hero__container container{% if padding_top != blank or padding_top_mobile != blank %} hero__container--padding-top{% endif %}{% if padding_bottom != blank or padding_bottom_mobile != blank %} hero__container--padding-bottom{%- endif -%}">
     <div class="hero__content">
       <h1 class="hero__title">
-        {{- custom_title | default: collection.title | default: page.title | default: cart.title -}}
+        {%- if section_preview -%}
+          Title
+        {%- else -%}
+          {%- if custom_title == blank and collection.title == blank and page.title == blank and cart.title == blank -%}
+            {%- assign custom_title = "Title" -%}
+          {%- endif -%}
+
+          {{- custom_title | default: collection.title | default: page.title | default: cart.title -}}
+        {%- endif -%}
       </h1>
 
       <div class="hero__description text-medium bq-content rx-content">
-        {{- custom_description | default: collection.description | default: page.content -}}
+        {%- unless section_preview -%}
+          {{- custom_description | default: collection.description | default: page.content -}}
+        {%- endunless -%}
       </div>
     </div>
   </div>
@@ -142,8 +152,7 @@
       {
         "type": "text",
         "id": "custom_title",
-        "label": "Custom title",
-        "default": "Title"
+        "label": "Custom title"
       },
       {
         "type": "contentEditor",

--- a/templates/cart.json
+++ b/templates/cart.json
@@ -7,7 +7,7 @@
       "block_order": [],
       "settings": {
         "color_palette": "two",
-        "custom_title": "Cart",
+        "custom_title": "",
         "overlay_opacity": 80,
         "padding_bottom": "medium",
         "padding_bottom_mobile": "medium",

--- a/templates/page.json
+++ b/templates/page.json
@@ -7,7 +7,8 @@
       "block_order": [],
       "settings": {
         "color_palette": "two",
-        "custom_title": "Page",
+        "custom_description": "{{ page.content }}",
+        "custom_title": "{{ page.title }}",
         "overlay_opacity": 80,
         "padding_bottom": "medium",
         "padding_bottom_mobile": "medium",


### PR DESCRIPTION
The customer complains that they are using our Translations feature but translation is applied to the browser tab and not the Cart page title:

<img width="1070" alt="GUA-1055 Missing Translation" src="https://github.com/user-attachments/assets/d11d47f2-27cb-4002-86c0-c464a96dcc22" />


Therefore, this PR aims to add {{ cart.title }}, {{ page.title }} and {{ page.content }} as a default values to related pages


![Arc 2025-01-28 13 48 10](https://github.com/user-attachments/assets/4f8768d9-8fa4-4e41-90e8-f7892e652038)
![Arc 2025-01-28 13 47 46](https://github.com/user-attachments/assets/3136f1f1-72cc-4b04-a7e9-b1cf3da8a017)
