### PR TITLE
Add padding for product description

### DIFF
--- a/assets/product-page.css
+++ b/assets/product-page.css
@@ -46,6 +46,10 @@
   padding: 0 0 25px;
 }
 
+.product-main__description:last-child {
+  padding: 40px 0 0;
+}
+
 .product-main__variation-label {
   margin-bottom: 6px;
 }
@@ -88,10 +92,6 @@
   justify-content: center;
   font-size: 12px;
   padding: 23px 0 32px;
-}
-
-.product-main__quantity:has(+ .product-main__description) {
-  padding: 0 0 40px;
 }
 
 .palette-one.product-main__holder {

--- a/assets/product-page.css
+++ b/assets/product-page.css
@@ -90,6 +90,10 @@
   padding: 23px 0 32px;
 }
 
+.product-main__quantity:has(+ .product-main__description) {
+  padding: 0 0 40px;
+}
+
 .palette-one.product-main__holder {
   color: var(--color-primary, #0B1A26);
   background: var(--background-primary, #FFFFFF);


### PR DESCRIPTION
This PR's purpose is to add padding for product description when it is below the `Add to cart` button on the product page

Before:

![Screenshot 2025-02-03 at 12 18 04 PM](https://github.com/user-attachments/assets/c9188181-3eaf-4271-ac23-b9dd8ee5fb2f)


After:

![Finder 2025-02-03 14 08 44](https://github.com/user-attachments/assets/0dd36223-52d5-4a34-a464-a6522640c38e)
