### PR TITLE
Add new border-radius option for styling block and image components

### DIFF
--- a/assets/accordion-block.css
+++ b/assets/accordion-block.css
@@ -11,7 +11,7 @@
   padding: 0;
   position: relative;
   border: 1px solid transparent;
-  border-radius: var(--border-radius-rounded, 0);
+  border-radius: var(--border-radius-block-rounded);
 }
 
 .accordion-block__heading {

--- a/assets/account.css
+++ b/assets/account.css
@@ -81,7 +81,7 @@
 }
 
 .account-fieldset__input {
-  border-radius: var(--border-radius-rounded, 0);
+  border-radius: var(--border-radius-rounded);
   border: 1px solid transparent;
   font-size: 16px;
   line-height: var(--line-height-xl, 2);
@@ -179,7 +179,7 @@
   cursor: pointer;
   display: inline-block;
   vertical-align: bottom;
-  border-radius: var(--border-radius-checkbox, 0);
+  border-radius: var(--border-radius-checkbox);
 }
 
 [id^='user_agreement_accepted']:checked + .account-checkbox__label:after {
@@ -226,7 +226,7 @@
   height: 100%;
   display: block;
   overflow: hidden;
-  border-radius: var(--border-radius-rounded, 0);
+  border-radius: var(--border-radius-rounded);
 }
 
 .account__agreement-text {
@@ -235,7 +235,7 @@
   height: 100%;
   overflow-x: hidden;
   overflow-y: auto;
-  border-radius: var(--border-radius-rounded, 0);
+  border-radius: var(--border-radius-rounded);
 }
 
 .account__agreement-closer {
@@ -284,7 +284,7 @@
   top: 50%;
   transform: translate(0, -50%);
   padding: 0 5px;
-  border-radius: var(--border-radius-rounded, 0);
+  border-radius: var(--border-radius-rounded);
   background:  var(--color-red-light, #F5CFCF);
   color: var(--color-red, #C23434);
   pointer-events: none;
@@ -304,7 +304,7 @@
 }
 
 .account__alert {
-  border-radius: var(--border-radius-rounded, 0);
+  border-radius: var(--border-radius-rounded);
   margin-bottom: 24px;
   padding: 14px 16px;
   font-size: 14px;

--- a/assets/base.css
+++ b/assets/base.css
@@ -296,7 +296,7 @@ ul{
 input,
 textarea {
   font-family: var(--font-body, sans-serif);
-  border-radius: var(--border-radius-rounded, 0);
+  border-radius: var(--border-radius-rounded);
 }
 
 input:-webkit-autofill,
@@ -418,7 +418,7 @@ img {
   line-height: var(--line-height-sm, 1.2);
   color: currentColor;
   border: 1px solid transparent;
-  border-radius: var(--border-radius-dynamic, 0);
+  border-radius: var(--border-radius-dynamic);
   background: none;
   cursor: pointer;
   margin-bottom: var(--button-margin-bottom, 16px);

--- a/assets/carousel.css
+++ b/assets/carousel.css
@@ -117,7 +117,7 @@
 
 .carousel__btn {
   margin: 0 8px;
-  border-radius: var(--border-radius-dynamic, 50%);
+  border-radius: var(--border-radius-dynamic);
   width: 48px;
   height: 48px;
   border: 1px solid transparent;
@@ -213,7 +213,7 @@
   cursor: pointer;
   width: 40px;
   height: 40px;
-  border-radius: var(--border-radius-dynamic, 0);
+  border-radius: var(--border-radius-dynamic);
   margin: 0;
   z-index: 2;
   line-height: var(--line-height-xs, 1);

--- a/assets/collections.css
+++ b/assets/collections.css
@@ -27,6 +27,7 @@
   height: 100%;
   position: relative;
   overflow: hidden;
+  border-radius: var(--border-radius-block-rounded);
 }
 
 .collections__item:last-child {

--- a/assets/columns.css
+++ b/assets/columns.css
@@ -23,6 +23,7 @@
   flex-direction: column;
   border: 1px solid transparent;
   position: relative;
+  border-radius: var(--border-radius-block-rounded);
 }
 
 .columns__image-wrapper {

--- a/assets/contact-form.css
+++ b/assets/contact-form.css
@@ -60,7 +60,12 @@
   aspect-ratio: 16 / 9;
 }
 
+.contact-form__image-wrapper:after {
+  border-radius: var(--border-radius-block-rounded);
+}
+
 .contact-form__image {
+  border-radius: var(--border-radius-block-rounded);
   width: 100%;
 }
 

--- a/assets/cookie-notice-preferences.css
+++ b/assets/cookie-notice-preferences.css
@@ -12,7 +12,7 @@
 
 .cookie-notice-preferences__inner {
   border: 1px solid transparent;
-  border-radius: var(--border-radius-rounded);
+  border-radius: var(--border-radius-block-rounded);
   padding: 16px 24px;
   display: flex;
   justify-content: space-between;

--- a/assets/footer.css
+++ b/assets/footer.css
@@ -88,7 +88,7 @@
 }
 
 #section-footer .footer__app .weglot-widget__wrapper {
-  border-radius: var(--border-radius-dynamic, 0);
+  border-radius: var(--border-radius-dynamic);
   transition: all var(--animation-duration) var(--transition-function-ease-in-out);
 }
 
@@ -100,7 +100,7 @@
   left: 50%;
   transform: translate(-50%, 0);
   border: 1px solid var(--color-border, #0B1A2626);
-  border-radius: var(--border-radius-rounded, 0);
+  border-radius: var(--border-radius-rounded);
   transition: all var(--animation-duration) var(--transition-function-ease-in-out);
 }
 

--- a/assets/header.css
+++ b/assets/header.css
@@ -149,7 +149,7 @@
   align-items: center;
   background: none;
   border: none;
-  border-radius: var(--border-radius-rounded, 0);
+  border-radius: var(--border-radius-rounded);
   cursor: pointer;
 }
 
@@ -189,7 +189,7 @@
   font-size: 16px;
   line-height: var(--line-height-sm, 1.2);
   border: 1px solid transparent;
-  border-radius: var(--border-radius-rounded, 0);
+  border-radius: var(--border-radius-rounded);
 }
 
 .header__search-input:focus {
@@ -251,7 +251,7 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
 }
 
 #section-header .app-mobile .weglot-widget__wrapper {
-  border-radius: var(--border-radius-dynamic, 0);
+  border-radius: var(--border-radius-dynamic);
   transition: all var(--animation-duration) var(--transition-function-ease-in-out);
 }
 
@@ -262,7 +262,7 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
 #section-header .app-mobile .weglot-widget__dropdown {
   left: 0;
   border: 1px solid var(--color-border, #0B1A2626);
-  border-radius: var(--border-radius-rounded, 0);
+  border-radius: var(--border-radius-rounded);
   transition: all var(--animation-duration) var(--transition-function-ease-in-out);
 }
 
@@ -764,7 +764,7 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
   }
 
   #section-header .header__app .weglot-widget__wrapper {
-    border-radius: var(--border-radius-dynamic, 0);
+    border-radius: var(--border-radius-dynamic);
     padding: 0;
     border: none;
   }
@@ -777,7 +777,7 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
     left: 50%;
     transform: translate(-50%, 0);
     border: 1px solid var(--color-border, #0B1A2626);
-    border-radius: var(--border-radius-rounded, 0);
+    border-radius: var(--border-radius-rounded);
     transition: all var(--animation-duration) var(--transition-function-ease-in-out);
   }
 

--- a/assets/mosaic.css
+++ b/assets/mosaic.css
@@ -15,6 +15,7 @@
   border: 1px solid transparent;
   overflow: hidden;
   margin: 0 0 30px;
+  border-radius: var(--border-radius-block-rounded);
 }
 
 .mosaic__item-col {
@@ -54,6 +55,7 @@
 
 .mosaic__image {
   max-height: 50px;
+  border-radius: var(--border-radius-block-rounded);
 }
 
 .mosaic__list-left .mosaic__item:nth-child(3n + 1) .mosaic__item-col:first-child,

--- a/assets/numbered-blocks.css
+++ b/assets/numbered-blocks.css
@@ -30,6 +30,7 @@
   padding: 0;
   border: 1px solid transparent;
   border-top: none;
+  border-radius: var(--border-radius-block-rounded);
   overflow: hidden;
 }
 
@@ -45,7 +46,7 @@
   font-size: 46px;
   line-height: var(--line-height-xs, 1);
   font-weight: var(--font-weight-medium, 500);
-  border-radius: var(--border-radius-circle, 0);
+  border-radius: var(--border-radius-circle);
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/assets/pagination.css
+++ b/assets/pagination.css
@@ -53,13 +53,13 @@
 }
 
 .pagination .prev {
-  border-top-left-radius: var(--border-radius-dynamic, 0);
-  border-bottom-left-radius: var(--border-radius-dynamic, 0);
+  border-top-left-radius: var(--border-radius-dynamic);
+  border-bottom-left-radius: var(--border-radius-dynamic);
 }
 
 .pagination .next {
-  border-top-right-radius: var(--border-radius-dynamic, 0);
-  border-bottom-right-radius: var(--border-radius-dynamic, 0);
+  border-top-right-radius: var(--border-radius-dynamic);
+  border-bottom-right-radius: var(--border-radius-dynamic);
 }
 
 .palette-one .pagination span {

--- a/assets/product-card.css
+++ b/assets/product-card.css
@@ -4,6 +4,7 @@
   position: relative;
   min-width: 298px;
   overflow: clip;
+  border-radius: var(--border-radius-block-rounded);
 }
 
 .product-card__vision {

--- a/assets/rx.css
+++ b/assets/rx.css
@@ -310,7 +310,7 @@
 .bq-content.rx-content samp,
 .bq-content.rx-content kbd,
 .bq-content.rx-content code {
-  border-radius: var(--border-radius-rounded, 0);
+  border-radius: var(--border-radius-rounded);
 }
 
 .bq-content.rx-content kbd {

--- a/assets/sidebar.css
+++ b/assets/sidebar.css
@@ -7,6 +7,7 @@
   padding: 16px;
   font-weight: var(--font-weight-headers, 600);
   border: 1px solid transparent;
+  border-radius: var(--border-radius-rounded);
 }
 
 .sidebar__nav-opener svg {

--- a/assets/tabs.css
+++ b/assets/tabs.css
@@ -16,7 +16,12 @@
   display: block;
   padding: 16px;
   position: relative;
-  border-radius: var(--border-radius-rounded, 0);
+  border-radius: var(--border-radius-block-rounded);
+  transition: border-radius var(--animation-duration, 200ms) var(--transition-function-ease-out);
+}
+
+.tabs__tab .tabs__trigger {
+  border-radius: 0;
 }
 
 .tabs__trigger:before {
@@ -27,8 +32,8 @@
   bottom: 10%;
   width: 3px;
   opacity: 0;
-  border-top-right-radius: var(--border-radius-rounded, 0);
-  border-bottom-right-radius: var(--border-radius-rounded, 0);
+  border-top-right-radius: var(--border-radius-block-rounded);
+  border-bottom-right-radius: var(--border-radius-block-rounded);
   visibility: hidden;
   transition: opacity var(--animation-duration, 200ms) var(--transition-function-ease-out);
 }
@@ -67,6 +72,8 @@
 .tabs__content {
   display: none;
   height: 100%;
+  overflow: clip;
+  border-radius: var(--border-radius-block-rounded);
 }
 
 .tabs__content.active {
@@ -97,6 +104,7 @@
   padding: 16px;
   font-weight: var(--font-weight-semibold, 600);
   border: 1px solid transparent;
+  border-radius: var(--border-radius-rounded);
 }
 
 .tabs__select-opener svg {
@@ -112,18 +120,24 @@
   border: 1px solid transparent;
   border-top-width: 0;
   border-bottom-width: 0;
-  transition: all var(--animation-duration, 200ms) var(--transition-function-ease-out),
-      max-height var(--animation-duration, 200ms) var(--transition-function-ease-out);;
+  border-bottom-right-radius: var(--border-radius-rounded);
+  border-bottom-left-radius: var(--border-radius-rounded);
+  transition: all var(--animation-duration, 200ms) var(--transition-function-ease-out);
+}
+
+.tabs__select #tabs-select-opener:checked ~ .tabs__select-opener {
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.tabs__select #tabs-select-opener:checked ~ .tabs__select-opener svg {
+  transform: rotate(270deg);
 }
 
 .tabs__select #tabs-select-opener:checked ~ .tabs__select-drop {
   pointer-events: all;
   max-height: 1000px;
   border-bottom-width: 1px;
-}
-
-.tabs__select #tabs-select-opener:checked ~ .tabs__select-opener svg {
-  transform: rotate(270deg);
 }
 
 .palette-one .tabs {
@@ -202,11 +216,6 @@
 }
 
 @media (min-width: 768px) {
-  .tabs {
-    grid-template-columns: 1.5fr 2fr;
-    direction : var(--direction, ltr);
-  }
-
   .tabs__select-opener {
     display: none;
   }
@@ -220,6 +229,10 @@
   .tabs__trigger {
     border: 1px solid transparent;
     margin: 0 0 16px;
+  }
+
+  .tabs__tab .tabs__trigger {
+    border-radius: var(--border-radius-block-rounded);
   }
 
   .tabs__trigger:last-child {
@@ -245,6 +258,8 @@
 
 @media (min-width: 992px) {
   .tabs {
+    grid-template-columns: 1.5fr 2fr;
+    direction : var(--direction, ltr);
     gap: 30px;
   }
 

--- a/assets/testimonials.css
+++ b/assets/testimonials.css
@@ -51,6 +51,7 @@
 
 .testimonials__image {
   margin: 0 auto;
+  border-radius: var(--border-radius-block-rounded);
 }
 
 .testimonials__content {

--- a/assets/text-with-image.css
+++ b/assets/text-with-image.css
@@ -49,10 +49,12 @@
   width: 100%;
   height: 100%;
   margin: var(--text-margin-top) 0 var(--text-margin-bottom);
+  border-radius: var(--border-radius-block-rounded);
 }
 
 .text-image__image {
   width: 100%;
+  border-radius: var(--border-radius-block-rounded);
 }
 
 .text-image__bg-default-wrapper,

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -64,7 +64,7 @@
       },
       {
         "type": "paragraph",
-        "content": "Make rounded corners of the Date picker, buttons, input fields, etc."
+        "content": "Make rounded corners of the Date picker, buttons, form fields (input, textarea, select, error message)"
       },
       {
         "type": "select",
@@ -89,6 +89,33 @@
           {
             "value": "max",
             "label": "Max"
+          }
+        ],
+        "default": "none"
+      },
+      {
+        "type": "paragraph",
+        "content": "Make rounded corners of the images and small blocks"
+      },
+      {
+        "type": "select",
+        "id": "rounded_corners_blocks",
+        "options": [
+          {
+            "value": "none",
+            "label": "None"
+          },
+          {
+            "value": "sm",
+            "label": "Small"
+          },
+          {
+            "value": "md",
+            "label": "Medium"
+          },
+          {
+            "value": "lg",
+            "label": "Large"
           }
         ],
         "default": "none"

--- a/snippets/date-picker.liquid
+++ b/snippets/date-picker.liquid
@@ -122,7 +122,7 @@
   }
 
   #section-{{ key }} bq-date-picker {
-    --date-picker-border-radius: var(--border-radius-dynamic, 0);
+    --date-picker-border-radius: var(--border-radius-dynamic);
     --date-picker-cleanstate-padding: 11px 22px;
     --date-picker-section-padding: 12px;
     --date-picker-title-size: 16px;

--- a/snippets/root-styles.liquid
+++ b/snippets/root-styles.liquid
@@ -217,30 +217,41 @@
 
     {%- case settings.rounded_corners -%}
       {%- when 'none' -%}
+        --border-radius-checkbox: 0px;
+        --border-radius-circle: 0px;
         --border-radius-dynamic: 0px;
         --border-radius-rounded: 0px;
-        --border-radius-circle: 0px;
-        --border-radius-checkbox: 0px;
       {%- when 'sm' -%}
+        --border-radius-checkbox: 4px;
+        --border-radius-circle: 4px;
         --border-radius-dynamic: 4px;
         --border-radius-rounded: 4px;
-        --border-radius-circle: 4px;
-        --border-radius-checkbox: 4px;
       {%- when 'md' -%}
+        --border-radius-checkbox: 4px;
+        --border-radius-circle: 8px;
         --border-radius-dynamic: 8px;
         --border-radius-rounded: 8px;
-        --border-radius-circle: 8px;
-        --border-radius-checkbox: 4px;
       {%- when 'lg' -%}
+        --border-radius-checkbox: 4px;
+        --border-radius-circle: 16px;
         --border-radius-dynamic: 16px;
         --border-radius-rounded: 8px;
-        --border-radius-circle: 16px;
-        --border-radius-checkbox: 4px;
       {%- when 'max' -%}
+        --border-radius-checkbox: 4px;
+        --border-radius-circle: 50%;
         --border-radius-dynamic: 25px;
         --border-radius-rounded: 8px;
-        --border-radius-circle: 50%;
-        --border-radius-checkbox: 4px;
+    {%- endcase -%}
+
+    {%- case settings.rounded_corners_blocks -%}
+      {%- when 'none' -%}
+        --border-radius-block-rounded: 0px;
+      {%- when 'sm' -%}
+        --border-radius-block-rounded: 4px;
+      {%- when 'md' -%}
+        --border-radius-block-rounded: 8px;
+      {%- when 'lg' -%}
+        --border-radius-block-rounded: 16px;
     {%- endcase -%}
 
     {%- if settings.background_3 != blank -%}
@@ -252,7 +263,7 @@
 
   #cc-main {
     --cc-btn-border-radius: var(--border-radius-dynamic);
-    --cc-modal-border-radius: var(--border-radius-rounded);
+    --cc-modal-border-radius: var(--border-radius-block-rounded);
   }
 
   {%- case settings.cookie_notice_color_palette -%}

--- a/snippets/variables-cart-lines.liquid
+++ b/snippets/variables-cart-lines.liquid
@@ -1,8 +1,8 @@
 {% style %}
   bq-cart-lines {
     --line-image-size: var(--thumbnail-size, 80px);
-    --line-image-border-radius: 0;
-    --line-control-border-radius: var(--border-radius-dynamic, 0);
+    --line-image-border-radius: var(--border-radius-block-rounded);
+    --line-control-border-radius: var(--border-radius-dynamic);
     --line-availability-border: 1px solid;
     --line-title-font-size: 16px;
     --line-variations-font-size: 14px;

--- a/snippets/variables-cart-services.liquid
+++ b/snippets/variables-cart-services.liquid
@@ -2,9 +2,9 @@
   bq-cart-services {
     line-height: var(--line-height-sm, 1.2);
     --services-container-background: transparent;
-    --services-container-border-radius: 0;
+    --services-container-border-radius: var(--border-radius-block-rounded);
     --services-container-padding: 12px 16px 16px;
-    --service-checkbox-border-radius: var(--border-radius-checkbox, 0);
+    --service-checkbox-border-radius: var(--border-radius-checkbox);
     --service-checkbox-color: transparent;
     --service-checkbox-size: 20px;
     --service-name-font-size: 16px;

--- a/snippets/variables-cart-totals.liquid
+++ b/snippets/variables-cart-totals.liquid
@@ -1,7 +1,7 @@
 {% style %}
   bq-cart-totals {
     --book-button-label-weight: var(--font-weight-semibold, 600);
-    --book-button-button-border-radius: var(--border-radius-dynamic, 0);
+    --book-button-button-border-radius: var(--border-radius-dynamic);
     --book-button-control-height: 50px;
     --book-button-button-padding: 14px 24px;
     --book-button-button-width: 100%;
@@ -11,7 +11,7 @@
     --totals-total-font-size: 20px;
     --totals-total-font-weight: var(--font-weight-h2, 700);
     --totals-error-padding: 8px 16px;
-    --totals-error-border-radius: 0;
+    --totals-error-border-radius: var(--border-radius-rounded);
     --totals-error-background-color: var(--color-red-light, #F5CFCF);
     --totals-error-color: var(--color-red, #C23434);
     --totals-error-gap: 10px;

--- a/snippets/variables-product-gallery.liquid
+++ b/snippets/variables-product-gallery.liquid
@@ -2,15 +2,15 @@
   bq-product-gallery {
     --product-gallery-control-size: 40px;
     --product-gallery-control-padding: 0 5px;
-    --product-gallery-control-border-radius: var(--border-radius-dynamic, 0);
+    --product-gallery-control-border-radius: var(--border-radius-dynamic);
     --product-gallery-control-icon-size: 16px;
     --product-gallery-control-filter: blur(2px);
     --product-gallery-direction: column;
     --product-gallery-gap: 16px;
-    --product-gallery-preview-border-radius: 0;
+    --product-gallery-preview-border-radius: var(--border-radius-block-rounded);
     --product-gallery-preview-gap: 16px;
     --product-gallery-thumbnail-direction: row;
-    --product-gallery-thumbnail-border-radius: 0;
+    --product-gallery-thumbnail-border-radius: var(--border-radius-block-rounded);
     --product-gallery-thumbnail-size: var(--thumbnail-size, 80px);
 
     {% if color_palette == "one" %}

--- a/snippets/variables-product-quantity.liquid
+++ b/snippets/variables-product-quantity.liquid
@@ -1,12 +1,12 @@
 {%- style -%}
   bq-product-button {
-    --add-button-button-border-radius: var(--border-radius-dynamic, 0);
+    --add-button-button-border-radius: var(--border-radius-dynamic);
     --add-button-button-padding: 14px;
     --add-button-button-max-width: 100%;
     --add-button-button-width: 100%;
     --add-button-control-height: 50px;
     --add-button-gap: 16px;
-    --add-button-input-border-radius: var(--border-radius-rounded, 0);
+    --add-button-input-border-radius: var(--border-radius-rounded);
     --add-button-input-padding: 8px 12px;
     --add-button-input-width: 110px;
     --add-button-label-weight: 700;

--- a/snippets/variables-product-variations.liquid
+++ b/snippets/variables-product-variations.liquid
@@ -4,9 +4,9 @@
     --variation-select-font-size: 16px;
     --variation-select-padding: 0 40px 0 10px;
     --variation-select-control-height: 50px;
-    --variation-select-border-radius: var(--border-radius-rounded, 0);
+    --variation-select-border-radius: var(--border-radius-rounded);
     --bundle-items-image-size: 50px;
-    --bundle-items-image-border-radius: var(--border-radius-rounded, 0);
+    --bundle-items-image-border-radius: var(--border-radius-rounded);
     --bundle-items-cell-padding: 5px;
     --bundle-items-font-size: 15px;
 


### PR DESCRIPTION
Some customers would like to get rounded-cornered images and product cards 

So, this PR's purpose is to add a new option that regulates rounded corners of blocks (product cards, block in `Columns` section, image in `Text with image` section, etc.)

![Arc 2025-04-01 11 55 14](https://github.com/user-attachments/assets/6e3c6627-5cae-4fc9-beb5-6d4673ef4d36)


Before:
![Arc 2025-03-31 15 30 12](https://github.com/user-attachments/assets/a9e5324a-a8ef-4fb3-a99f-49f0499e0ad6)
![Arc 2025-03-31 15 29 59](https://github.com/user-attachments/assets/929a97b0-f5fc-4f5b-9124-e8c6ce82a566)


After:
![Arc 2025-03-31 15 30 30](https://github.com/user-attachments/assets/f66b1ad8-e72b-461c-a700-d9c1d7aeec85)
![Arc 2025-03-31 15 29 40](https://github.com/user-attachments/assets/a1f59d11-8a75-449c-acbd-c9529a636a08)
