### PR TITLE
Remove styles of the scrollbar

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -79,22 +79,6 @@
   font-family: var(--font-body, sans-serif);
 }
 
-* {
-  scrollbar-width: thin;
-  scrollbar-color: transparent transparent;
-}
-
-*::-webkit-scrollbar {
-  width: 1px;
-}
-
-*::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-*::-webkit-scrollbar-thumb {
-  background: transparent;
-}
 
 html {
   overflow-x: hidden;
@@ -121,11 +105,6 @@ body {
   width: 100%;
   overflow-x: hidden;
   overflow-wrap: anywhere;
-}
-
-body::-webkit-scrollbar {
-  width: 0;
-  height: 0;
 }
 
 body > * {

--- a/assets/carousel.css
+++ b/assets/carousel.css
@@ -4,17 +4,17 @@
   position: relative;
 }
 
-.carousel *::-webkit-scrollbar {
+.carousel *::-webkit-scrollbar,
+.carousel__wrapper::-webkit-scrollbar {
   width: 0;
   height: 0;
+  display: none; /* Completely hide scrollbar */
 }
 
-.carousel *::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.carousel *::-webkit-scrollbar-thumb {
-  background: transparent;
+.carousel,
+.carousel__wrapper {
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* IE/Edge */
 }
 
 .carousel__wrapper {
@@ -27,11 +27,8 @@
   scroll-snap-stop: always;
   scroll-padding: 0 16px 0 0;
   scroll-behavior: smooth !important;
-  -ms-overflow-style: none;
   display: flex;
   align-items: stretch;
-  scrollbar-width: none;
-  scrollbar-color: transparent transparent;
 }
 
 .carousel--controls .carousel__wrapper {

--- a/assets/sidebar.css
+++ b/assets/sidebar.css
@@ -88,6 +88,12 @@
   transition-property: max-height;
   transition-duration: var(--animation-duration, 200ms);
   transition-timing-function: var(--transition-function-ease-out);
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* IE/Edge */
+}
+
+.sidebar__menu-wrapper::-webkit-scrollbar {
+  display: none; /* Safari and Chrome */
 }
 
 .sidebar__menu-wrapper .sidebar__menu-list {


### PR DESCRIPTION
The scrollbar of the Chameleon-based themes is white, so customers do not notice or realize they need to scroll. 
Therefore, this PR aims to remove styles of scrollbar and let it be styled based on OS.

Before:
![image](https://github.com/user-attachments/assets/648b369d-9447-40e0-b161-b1621f76c1cc)

After:
![Arc 2025-04-21 19 47 30](https://github.com/user-attachments/assets/59ba16fa-47e6-4127-b403-70804111ab3c)
