### PR TITLE
Adds Content-Security-Policy meta tag for production-only environments

### DIFF
--- a/layout/checkout.liquid
+++ b/layout/checkout.liquid
@@ -8,6 +8,7 @@
         page_description: page_description,
         page_title: page_title,
         settings: settings,
+        is_local_env: local_env?,
         shop: shop
     -%}
 

--- a/layout/minimal.liquid
+++ b/layout/minimal.liquid
@@ -8,6 +8,7 @@
         page_description: page_description,
         page_title: page_title,
         settings: settings,
+        is_local_env: local_env?,
         shop: shop
     -%}
 

--- a/layout/session.liquid
+++ b/layout/session.liquid
@@ -8,6 +8,7 @@
         page_description: page_description,
         page_title: page_title,
         settings: settings,
+        is_local_env: local_env?,
         shop: shop
     -%}
 

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -8,6 +8,7 @@
         page_description: page_description,
         page_title: page_title,
         settings: settings,
+        is_local_env: local_env?,
         shop: shop
     -%}
 

--- a/snippets/page-base-meta.liquid
+++ b/snippets/page-base-meta.liquid
@@ -4,7 +4,9 @@
 {% comment %} Meta for improved performance and mobile experience {% endcomment %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="{%- if settings.accent_background != blank -%}{{- settings.accent_background -}}{%- else -%}{{- brand_color -}}{%- endif -%}">
-<meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
+{%- unless is_local_env -%}
+  <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
+{%- endunless -%}
 <meta name="color-scheme" content="light">
 <meta name="format-detection" content="telephone=no">
 


### PR DESCRIPTION
This pull request introduces an `is_local_env` flag across multiple layout files and updates the `page-base-meta` snippet to conditionally include a `Content-Security-Policy` meta tag based on the environment (it was added on https://github.com/booqable/chameleon-theme/pull/266)

Related https://github.com/booqable/booqable/pull/13577

Now assets are loaded correctly: 

![image](https://github.com/user-attachments/assets/bf9e471f-ee2d-4874-b79c-f85ae86dbbde)
