### PR TITLE
Fixes Liquid template errors

### DIFF
--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -281,7 +281,7 @@
         "type": "text",
         "id": "bottom_text",
         "label": "Bottom message",
-        "default": "{{ \"now\" | date: \"%Y\" }} {{ shop.name }}. All right reserved.",
+        "default": "{{ 'now' | date: '%Y' }} {{ shop.name }}. All right reserved.",
         "info": "This template keeps the year auto-updated and returns the name of your company. Leave blank to hide the text"
       },
       {

--- a/sections/images.liquid
+++ b/sections/images.liquid
@@ -89,11 +89,11 @@
   {%- assign default_color = nil -%}
 
   {%- if color_palette == "one" -%}
-    {%- assign default_color = settings.primary_color | default : #0B1A26 -%}
+    {%- assign default_color = settings.primary_color | default : '#0B1A26' -%}
   {%- elsif color_palette == "two" -%}
-    {%- assign default_color = settings.primary_color_2 | default : #FFFFFF -%}
+    {%- assign default_color = settings.primary_color_2 | default : '#FFFFFF' -%}
   {%- elsif color_palette == "three" -%}
-    {%- assign default_color = settings.primary_color_3 | default : #0B1A26 -%}
+    {%- assign default_color = settings.primary_color_3 | default : '#0B1A26' -%}
   {%- endif -%}
 
   {%- if show_datepicker -%}


### PR DESCRIPTION
Fixes some Liquid errors.

Example:

![image](https://github.com/user-attachments/assets/430d1fe2-b2c4-4c53-84d6-9b4c09f1b443)

We're experimenting with `strict` mode instead of `lax` that help us discover these errors (see: https://github.com/Shopify/liquid?tab=readme-ov-file#error-modes)