### PR TITLE
Add app section previews

### DIFF
--- a/assets/app.css
+++ b/assets/app.css
@@ -15,6 +15,19 @@
   display: none;
 }
 
+.app__preview {
+  height: 200px;
+  border-radius: var(--border-radius-block-rounded);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.app__preview span {
+  display: block;
+  padding: 8px 12px;
+}
+
 .accessibe-widget {
   justify-content: flex-start !important;
   margin: 10px 0;
@@ -121,6 +134,21 @@
   background: var(--background-primary, #FFFFFF);
 }
 
+.palette-one .app__preview {
+  background-image: repeating-linear-gradient(
+    315deg,
+    var(--background-primary, #FFFFFF),
+    var(--background-primary, #FFFFFF) 6px,
+    var(--color-border, #0B1A2626) 6px,
+    var(--color-border, #0B1A2626) 7px
+  ) !important;
+}
+
+.palette-one .app__preview span {
+  background-color: var(--background-primary, #FFFFFF);
+  color: var(--color-primary, #0B1A26);
+}
+
 .palette-one .accessibe-widget .accessibe-widget__wrapper {
   border-color: var(--color-border, #0B1A2626);
 }
@@ -166,6 +194,21 @@
   background: var(--background-primary-2, #0B1A26);
 }
 
+.palette-two .app__preview {
+  background-image: repeating-linear-gradient(
+    315deg,
+    var(--background-primary-2, #0B1A26),
+    var(--background-primary-2, #0B1A26) 6px,
+    var(--color-border-2, #FFFFFF47) 6px,
+    var(--color-border-2, #FFFFFF47) 7px
+  ) !important;
+}
+
+.palette-two .app__preview span {
+  background-color: var(--background-primary-2, #0B1A26);
+  color: var(--color-primary-2, #FFFFFF);
+}
+
 .palette-two .accessibe-widget .accessibe-widget__wrapper {
   border-color: var(--color-border-2, #FFFFFF47);
 }
@@ -209,6 +252,21 @@
 .palette-three.app__wrapper {
   color: var(--color-primary-3, #0B1A26);
   background: var(--background-primary-3, #F4B841);
+}
+
+.palette-three .app__preview {
+  background-image: repeating-linear-gradient(
+    315deg,
+    var(--background-primary-3, #F4B841),
+    var(--background-primary-3, #F4B841) 6px,
+    var(--color-border-3, #0B1A2626) 6px,
+    var(--color-border-3, #0B1A2626) 7px
+  ) !important;
+}
+
+.palette-three .app__preview span {
+  background-color: var(--background-primary-3, #F4B841);
+  color: var(--color-primary-3, #0B1A26);
 }
 
 .palette-three .accessibe-widget .accessibe-widget__wrapper {

--- a/sections/app.liquid
+++ b/sections/app.liquid
@@ -1,70 +1,73 @@
-{%- assign app = section.blocks | where: "type", "app" | first -%}
+{{ "app.css" | asset_url | stylesheet_tag }}
 
-{%- if app != blank -%}
-  {{ "app.css" | asset_url | stylesheet_tag }}
+{%- assign app                   = section.blocks | where: "type", "app" | first -%}
+{%- assign color_palette         = section.settings.color_palette -%}
+{%- assign padding_bottom        = section.settings.padding_bottom -%}
+{%- assign padding_bottom_mobile = section.settings.padding_bottom_mobile -%}
+{%- assign padding_top           = section.settings.padding_top -%}
+{%- assign padding_top_mobile    = section.settings.padding_top_mobile -%}
 
-  {%- assign color_palette         = section.settings.color_palette -%}
-  {%- assign padding_bottom        = section.settings.padding_bottom -%}
-  {%- assign padding_bottom_mobile = section.settings.padding_bottom_mobile -%}
-  {%- assign padding_top           = section.settings.padding_top -%}
-  {%- assign padding_top_mobile    = section.settings.padding_top_mobile -%}
+{% comment %} CSS variables start {% endcomment %}
+{%- capture variables -%}
+  {%- case padding_top -%}
+    {%- when 'none' -%}
+      --padding-top: 0;
+    {%- when 'small' -%}
+      --padding-top: 24px;
+    {%- when 'medium' -%}
+      --padding-top: 68px;
+    {%- when 'large' -%}
+      --padding-top: 112px;
+  {%- endcase -%}
 
-  {% comment %} CSS variables start {% endcomment %}
-  {%- capture variables -%}
-    {%- case padding_top -%}
-      {%- when 'none' -%}
-        --padding-top: 0;
-      {%- when 'small' -%}
-        --padding-top: 24px;
-      {%- when 'medium' -%}
-        --padding-top: 68px;
-      {%- when 'large' -%}
-        --padding-top: 112px;
-    {%- endcase -%}
+  {%- case padding_bottom -%}
+    {%- when 'none' -%}
+      --padding-bottom: 0;
+    {%- when 'small' -%}
+      --padding-bottom: 24px;
+    {%- when 'medium' -%}
+      --padding-bottom: 68px;
+    {%- when 'large' -%}
+      --padding-bottom: 112px;
+  {%- endcase -%}
 
-    {%- case padding_bottom -%}
-      {%- when 'none' -%}
-        --padding-bottom: 0;
-      {%- when 'small' -%}
-        --padding-bottom: 24px;
-      {%- when 'medium' -%}
-        --padding-bottom: 68px;
-      {%- when 'large' -%}
-        --padding-bottom: 112px;
-    {%- endcase -%}
+  {%- case padding_top_mobile -%}
+    {%- when 'none' -%}
+      --padding-top-mobile: 0;
+    {%- when 'small' -%}
+      --padding-top-mobile: 18px;
+    {%- when 'medium' -%}
+      --padding-top-mobile: 54px;
+    {%- when 'large' -%}
+      --padding-top-mobile: 90px;
+  {%- endcase -%}
 
-    {%- case padding_top_mobile -%}
-      {%- when 'none' -%}
-        --padding-top-mobile: 0;
-      {%- when 'small' -%}
-        --padding-top-mobile: 18px;
-      {%- when 'medium' -%}
-        --padding-top-mobile: 54px;
-      {%- when 'large' -%}
-        --padding-top-mobile: 90px;
-    {%- endcase -%}
+  {%- case padding_bottom_mobile -%}
+    {%- when 'none' -%}
+      --padding-bottom-mobile: 0;
+    {%- when 'small' -%}
+      --padding-bottom-mobile: 18px;
+    {%- when 'medium' -%}
+      --padding-bottom-mobile: 54px;
+    {%- when 'large' -%}
+      --padding-bottom-mobile: 90px;
+  {%- endcase -%}
+{%- endcapture -%}
+{% comment %} CSS variables end {% endcomment %}
 
-    {%- case padding_bottom_mobile -%}
-      {%- when 'none' -%}
-        --padding-bottom-mobile: 0;
-      {%- when 'small' -%}
-        --padding-bottom-mobile: 18px;
-      {%- when 'medium' -%}
-        --padding-bottom-mobile: 54px;
-      {%- when 'large' -%}
-        --padding-bottom-mobile: 90px;
-    {%- endcase -%}
-  {%- endcapture -%}
-  {% comment %} CSS variables end {% endcomment %}
-
-  <div class="app__wrapper {% if color_palette != blank %} palette-{{ color_palette }}{% endif %}{% if padding_top != blank or padding_top_mobile != blank %} app__wrapper--padding-top{% endif %}{% if padding_bottom != blank or padding_bottom_mobile != blank %} app__wrapper--padding-bottom{%- endif -%}" style="{{- variables | escape -}}">
-    <div class="app__container container">
+<div class="app__wrapper {% if color_palette != blank %} palette-{{ color_palette }}{% endif %}{% if padding_top != blank or padding_top_mobile != blank %} app__wrapper--padding-top{% endif %}{% if padding_bottom != blank or padding_bottom_mobile != blank %} app__wrapper--padding-bottom{%- endif -%}" style="{{- variables | escape -}}">
+  <div class="app__container container">
+    {%- unless section_preview -%}
       <div class="app__content">
         {% render 'app', block: app, section: section %}
       </div>
-    </div>
+    {%- else -%}
+      <div class="app__preview">
+        <span>The contents of this section vary by App.</span>
+      </div>
+    {%- endunless -%}
   </div>
-{%- endif -%}
+</div>
 
 {% schema %}
   {


### PR DESCRIPTION
This PR introduces a new "preview mode" for the app section and updates the styling to support different color palettes. The changes include enhancements to the CSS for consistent visual presentation and modifications to the Liquid template for conditional rendering of the preview content.

### Styling Updates for Preview Mode:
* [`assets/app.css`](diffhunk://#diff-0cdd3400a6c98881ff1071940718d3eb6c0df60ea25effaee1d0f749ac0c4bd0R18-R30): Added `.app__preview` class with styling for height, border-radius, and center alignment. Specific styles for `.palette-one`, `.palette-two`, and `.palette-three` were added to define background gradients and text colors for the preview mode. [[1]](diffhunk://#diff-0cdd3400a6c98881ff1071940718d3eb6c0df60ea25effaee1d0f749ac0c4bd0R18-R30) [[2]](diffhunk://#diff-0cdd3400a6c98881ff1071940718d3eb6c0df60ea25effaee1d0f749ac0c4bd0R137-R151) [[3]](diffhunk://#diff-0cdd3400a6c98881ff1071940718d3eb6c0df60ea25effaee1d0f749ac0c4bd0R197-R211) [[4]](diffhunk://#diff-0cdd3400a6c98881ff1071940718d3eb6c0df60ea25effaee1d0f749ac0c4bd0R257-R271)

### Template Enhancements for Conditional Rendering:
* [`sections/app.liquid`](diffhunk://#diff-a81caf6cda2f8208ab5615d53feeb90942792cb5e77288a640fb73ef9c02e72cR60-L67): Modified the template to include conditional logic for rendering either the app content or a preview mode with placeholder text based on the `section_preview` variable.
* [`sections/app.liquid`](diffhunk://#diff-a81caf6cda2f8208ab5615d53feeb90942792cb5e77288a640fb73ef9c02e72cL1-R3): Adjusted variable assignments for improved readability and consistency.