### PR TITLE
Fix the wrong Liquid syntax of fonts

### DIFF
--- a/snippets/fonts.liquid
+++ b/snippets/fonts.liquid
@@ -9,5 +9,5 @@
   {{- settings.body_font | font_link -}}
 {%- endif -%}
 {%- if settings.tagline_font != blank -%}
-  {{- settings.tagline_font | font_link =}}
+  {{- settings.tagline_font | font_link -}}
 {%- endif -%}


### PR DESCRIPTION
This PR includes a minor fix in the `snippets/fonts.liquid` file. The change corrects a syntax issue by removing an unnecessary `=` in the `font_link` filter for the `settings.tagline_font` variable.