### PR TITLE
Update app.liquid to show preview content if no app is chosen

### DIFF
--- a/sections/app.liquid
+++ b/sections/app.liquid
@@ -57,15 +57,15 @@
 
 <div class="app__wrapper {% if color_palette != blank %} palette-{{ color_palette }}{% endif %}{% if padding_top != blank or padding_top_mobile != blank %} app__wrapper--padding-top{% endif %}{% if padding_bottom != blank or padding_bottom_mobile != blank %} app__wrapper--padding-bottom{%- endif -%}" style="{{- variables | escape -}}">
   <div class="app__container container">
-    {%- unless section_preview -%}
-      <div class="app__content">
-        {% render 'app', block: app, section: section %}
-      </div>
-    {%- else -%}
+    {%- if section_preview or app == nil -%}
       <div class="app__preview">
         <span>The contents of this section vary by App.</span>
       </div>
-    {%- endunless -%}
+    {%- else -%}
+      <div class="app__content">
+        {% render 'app', block: app, section: section %}
+      </div>
+    {%- endif -%}
   </div>
 </div>
 


### PR DESCRIPTION
This pull request modifies the logic in the `sections/app.liquid` file to improve how the app section handles previews and missing app data.

### Changes to section rendering logic:

* Updated the conditional logic to explicitly check for `section_preview` or a `nil` value for the `app` variable. This ensures that the preview message is displayed when either condition is met.
* Replaced the `unless` block with a more explicit `if`/`else` structure, improving code readability and maintainability.