### PR TITLE
Remove max-height of image holder in the text-image section

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -121,6 +121,11 @@ body > * {
   width: 100%;
 }
 
+#main > section:first-child:is(.text-image) .text-image__holder,
+#main > .text-image:first-child .text-image__holder {
+  max-height: none;
+}
+
 #main > section:last-child {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
The customer reported that the `Text with Image` section in the Celebrate theme is not centering the text to be aligned with the center of the image. 
So they had to add line breaks at the end of the text so it's aligned to the center.

Page template: https://event-rent-me-llc.booqable.com/themes/f14a6f12-169b-45d2-86a6-371aca40b38f?template=page.json
![image](https://github.com/user-attachments/assets/a23795e4-9292-4586-910c-14bb0f037ed2)


But this behaviour was made intentionally to fit the design. The idea was that if the image is too tall, it should overlap the previous section.
But in this case, the `Text with Image` section is the first one on the page, therefore, the part of the image is hidden behind the header.

So this PR makes a small addition to the `assets/base.css` file to improve the layout of the first `.text-image` section on a page. Specifically, it removes the `max-height` restriction for `.text-image__holder` elements when they are the first child of a section or the main container.

* [`assets/base.css`](diffhunk://#diff-00b03bd62b155daa89082ba52094c182e46422a9e28cd3ec601b3a2291b52718R124-R128): Added a new CSS rule to set `max-height: none;` for `.text-image__holder` elements in the first `.text-image` section or container.

### Before:
![Arc 2025-06-20 14 33 37](https://github.com/user-attachments/assets/aca0e13c-cf77-4d4e-9151-cae6c1203349)


### After:

![Arc 2025-06-20 14 32 55](https://github.com/user-attachments/assets/8d66567b-415e-4946-9794-d42bd11c3c10)
