### PR TITLE
Refactor font loading logic to ensure proper font preloading

### DIFF
--- a/snippets/fonts.liquid
+++ b/snippets/fonts.liquid
@@ -1,36 +1,74 @@
-{%- if settings.heading_font != blank -%}
-  {% assign heading_font_url = settings.heading_font | font_link | remove: '<link href="' | remove: '" rel="stylesheet" />' %}
-  <link rel="preload" as="style" href="{{ heading_font_url }}">
-{%- endif -%}
-{%- if settings.body_font != blank -%}
-  {% assign body_font_url = settings.body_font | font_link | remove: '<link href="' | remove: '" rel="stylesheet" />' %}
-  <link rel="preload" as="style" href="{{ body_font_url }}">
-{%- endif -%}
-{%- if settings.tagline_font != blank -%}
-  {% assign tagline_font_url = settings.tagline_font | font_link | remove: '<link href="' | remove: '" rel="stylesheet" />' %}
-  <link rel="preload" as="style" href="{{ tagline_font_url }}">
+{%- comment -%}
+  A fonts snippet that collects, filters and preloads fonts.
+{%- endcomment -%}
+
+{%- assign fonts = '' -%}
+{%- assign separator = '|FONT_SEP|' -%}
+{%- assign body_font = settings.body_font -%}
+{%- assign heading_font = settings.heading_font -%}
+{%- assign tagline_font = settings.tagline_font -%}
+
+{%- if heading_font != blank -%}
+  {%- assign heading_path = heading_font.path -%}
+
+  {%- unless fonts contains heading_path -%}
+    {%- if fonts == '' -%}
+      {%- assign fonts = heading_path -%}
+    {%- else -%}
+      {%- assign fonts = fonts | append: separator | append: heading_path -%}
+    {%- endif -%}
+  {%- endunless -%}
 {%- endif -%}
 
-{%- if settings.heading_font != blank -%}
-  <link rel="stylesheet" href="{{ heading_font_url }}" media="print" onload="this.media='all'">
-{%- endif -%}
-{%- if settings.body_font != blank -%}
-  <link rel="stylesheet" href="{{ body_font_url }}" media="print" onload="this.media='all'">
-{%- endif -%}
-{%- if settings.tagline_font != blank -%}
-  <link rel="stylesheet" href="{{ tagline_font_url }}" media="print" onload="this.media='all'">
+{%- if body_font != blank -%}
+  {%- assign body_path = body_font.path -%}
+
+  {%- unless fonts contains body_path -%}
+    {%- if fonts == '' -%}
+      {%- assign fonts = body_path -%}
+    {%- else -%}
+      {%- assign fonts = fonts | append: separator | append: body_path -%}
+    {%- endif -%}
+  {%- endunless -%}
 {%- endif -%}
 
-{%- if settings.heading_font != blank or settings.body_font != blank or settings.tagline_font != blank -%}
+{%- if tagline_font != blank -%}
+  {%- assign tagline_path = tagline_font.path -%}
+
+  {%- unless fonts contains tagline_path -%}
+    {%- if fonts == '' -%}
+      {%- assign fonts = tagline_path -%}
+    {%- else -%}
+      {%- assign fonts = fonts | append: separator | append: tagline_path -%}
+    {%- endif -%}
+  {%- endunless -%}
+{%- endif -%}
+
+{%- if fonts != '' -%}
+  {%- assign paths = fonts | split: separator -%}
+
+  {%- for path in paths -%}
+    <link rel="preload" as="style" href="{{ path }}">
+    <link rel="stylesheet" href="{{ path }}" media="print" onload="this.media='all'">
+  {%- endfor -%}
+
   <noscript>
-    {%- if settings.heading_font != blank -%}
-      {{- settings.heading_font | font_link -}}
+    {%- if heading_font != blank -%}
+      {%- if paths contains heading_path -%}
+        {{- settings.heading_font | font_link -}}
+      {%- endif -%}
     {%- endif -%}
-    {%- if settings.body_font != blank -%}
-      {{- settings.body_font | font_link -}}
+
+    {%- if body_font != blank -%}
+      {%- if paths contains body_path and body_path != heading_path -%}
+        {{- settings.body_font | font_link -}}
+      {%- endif -%}
     {%- endif -%}
-    {%- if settings.tagline_font != blank -%}
-      {{- settings.tagline_font | font_link -}}
+
+    {%- if tagline_font != blank -%}
+      {%- if paths contains tagline_path and tagline_path != heading_path and tagline_path != body_path -%}
+        {{- settings.tagline_font | font_link -}}
+      {%- endif -%}
     {%- endif -%}
   </noscript>
 {%- endif -%}


### PR DESCRIPTION
This pull request refactors the `snippets/fonts.liquid` file to improve the handling of font preloading and stylesheet linking. The changes consolidate logic, reduce redundancy, and ensure that fonts are processed more efficiently.

### Refactoring and Optimization:

* Consolidated the logic for collecting and preloading fonts into a single workflow, reducing repetitive code for handling `heading_font`, `body_font`, and `tagline_font`.
* Introduced a `separator` variable and used it to build a unique list of font paths, preventing duplicate font processing.
* Simplified the `<noscript>` block by reusing the preprocessed font paths, ensuring no redundant font links are generated for fallback scenarios.

### Before:
<img width="1419" height="173" alt="Arc 2025-07-15 12 39 00" src="https://github.com/user-attachments/assets/0286e51e-09b2-44a5-a22d-ad31ff93c3c3" />



### After: 
<img width="941" height="91" alt="Arc 2025-07-15 12 33 14" src="https://github.com/user-attachments/assets/f3fe64b6-6333-45d3-9838-7959a379cebc" />
