### PR TITLE
Refactor MegaMenuProcessor to use explicit method calls

### DIFF
--- a/assets/js-header-menu.js
+++ b/assets/js-header-menu.js
@@ -182,7 +182,7 @@ const MegaMenuProcessor = {
 
       if (isSearchOpener && menuIsOpened) {
         menuOpener.checked = false
-        this.closeMenu()
+        MegaMenuProcessor.closeMenu()
       }
       return
     }
@@ -194,14 +194,14 @@ const MegaMenuProcessor = {
     }
 
     const menuOpened = menuOpener && menuOpener.checked
-    menuOpened ? this.closeMenu() : MegaMenuRenderer.enableScrollPrevention()
+    menuOpened ? MegaMenuProcessor.closeMenu() : MegaMenuRenderer.enableScrollPrevention()
   },
 
   handleMenuResize: (() => {
     const resizeHandler = () => {
       const viewport = $.viewportSize()
       if (viewport.width < MegaMenuConfig.mediaQuery) return
-      this.closeMenu()
+      MegaMenuProcessor.closeMenu()
 
       if (!MegaMenuDOM.elements.menuOpener) return
       MegaMenuDOM.elements.menuOpener.checked = false
@@ -248,7 +248,7 @@ const MegaMenuProcessor = {
     if (!menuOpener?.checked) return
 
     menuOpener.checked = false
-    this.closeMenu()
+    MegaMenuProcessor.closeMenu()
   },
 
   closeHeaderModals () {


### PR DESCRIPTION
This PR refactors the `MegaMenuProcessor` object in `assets/js-header-menu.js` to improve code clarity and consistency by replacing the use of `this.closeMenu()` with `MegaMenuProcessor.closeMenu()` in several methods.

### Refactoring for consistency:
* Replaced `this.closeMenu()` with `MegaMenuProcessor.closeMenu()` in the `if` block inside the `handleMenuToggle` method to ensure consistent usage of the object reference.
* Updated the ternary operation in the `handleMenuToggle` method to use `MegaMenuProcessor.closeMenu()` instead of `this.closeMenu()`.
* Changed the `resizeHandler` function inside `handleMenuResize` to call `MegaMenuProcessor.closeMenu()` instead of `this.closeMenu()`.
* Refactored the condition in an unnamed method to use `MegaMenuProcessor.closeMenu()` for closing the menu, replacing `this.closeMenu()`.