### PR TITLE
Clean up the `Variation label`

### DIFF
--- a/sections/product-page.liquid
+++ b/sections/product-page.liquid
@@ -10,7 +10,7 @@
 {%- assign quantity                      = product | product_button -%}
 {%- assign price                         = product | product_price -%}
 {%- assign period                        = product | product_price_label -%}
-{%- assign variation_label               = 'store.variant' | user_t | default: section.settings.variation_label -%}
+{%- assign variation_label               = 'store.variant' | user_t -%}
 {%- assign message_label                 = section.settings.message_label -%}
 {%- assign show_controls                 = section.settings.show_controls -%}
 {%- assign show_thumbnails               = section.settings.show_thumbnails -%}

--- a/templates/construct/product.json
+++ b/templates/construct/product.json
@@ -30,8 +30,7 @@
         "padding_top_mobile": "small",
         "show_breadcrumbs": true,
         "show_controls": true,
-        "show_thumbnails": true,
-        "variation_label": "Variant"
+        "show_thumbnails": true
       },
       "disabled": null
     },

--- a/templates/product.json
+++ b/templates/product.json
@@ -30,8 +30,7 @@
         "padding_top_mobile": "small",
         "show_breadcrumbs": true,
         "show_controls": true,
-        "show_thumbnails": true,
-        "variation_label": "Variant"
+        "show_thumbnails": true
       },
       "disabled": null
     },

--- a/templates/romance/product.json
+++ b/templates/romance/product.json
@@ -30,8 +30,7 @@
         "padding_top_mobile": "small",
         "show_breadcrumbs": true,
         "show_controls": true,
-        "show_thumbnails": true,
-        "variation_label": "Variant"
+        "show_thumbnails": true
       },
       "disabled": null
     },

--- a/templates/vogue/product.json
+++ b/templates/vogue/product.json
@@ -30,8 +30,7 @@
         "padding_top_mobile": "small",
         "show_breadcrumbs": true,
         "show_controls": true,
-        "show_thumbnails": true,
-        "variation_label": "Variant"
+        "show_thumbnails": true
       },
       "disabled": null
     },


### PR DESCRIPTION
Since the `variation label` translation is not supported anymore on the theme side (https://github.com/booqable/chameleon-theme/pull/325), so the stuff related to that should be completely removed as well