### PR TITLE
Fix header logo stretches

### DIFF
--- a/assets/header.css
+++ b/assets/header.css
@@ -59,6 +59,7 @@
 .header__logo-image {
   max-height: 64px;
   max-width: 200px;
+  width: auto;
 }
 
 .header--menu-opened {


### PR DESCRIPTION
This PR updates the header logo width. The change ensures that the logo image maintains its aspect ratio by setting its width to auto, which helps prevent any distortions

### Before:
<img width="1288" height="104" alt="Arc 2025-08-27 11 34 18" src="https://github.com/user-attachments/assets/6a7275cf-5f2e-4e4c-8c84-a3ccd72864bd" />



### After:
<img width="1357" height="104" alt="Arc 2025-08-27 11 34 04" src="https://github.com/user-attachments/assets/bd522012-da53-40d8-8c69-94eeb898d222" />
